### PR TITLE
Feature: LTREE supported operations#2

### DIFF
--- a/lib/filter_lib/README.md
+++ b/lib/filter_lib/README.md
@@ -242,6 +242,10 @@ Available filter operations:
 - ``any``
 - ``not_any``
 - ``distinct``
+- ``parent``
+- ``parents_recursive``
+- ``children``
+- ``children_recursive``
 
 Available sort orders:
 - ``asc``

--- a/lib/filter_lib/requirements.txt
+++ b/lib/filter_lib/requirements.txt
@@ -1,4 +1,5 @@
 SQLAlchemy==1.3.23
 sqlalchemy-filters==0.12.0
+sqlalchemy_utils==0.38.3
 psycopg2-binary==2.9.1
 pydantic==1.8.2

--- a/lib/filter_lib/src/query_modificator.py
+++ b/lib/filter_lib/src/query_modificator.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm.query import Query
 from sqlalchemy_filters import apply_filters, apply_sort
 from sqlalchemy_filters.exceptions import BadFilterFormat, BadSpec
 
+from sqlalchemy_utils import LtreeType
+
 from .pagination import PaginationParams, make_pagination
 from .schema_generator import Pagination
 
@@ -119,6 +121,7 @@ def _create_sorting(query: Query, sor: Dict[str, Any]) -> Query:
 def _create_filter(query: Query, fil: Dict[str, Any]) -> Query:
     model = _get_entity(query, fil.get("model"))
     field = fil.get("field")
+    op = fil.get("op")
     value = fil.get("value")
 
     if _has_relation(model, field) and _op_is_match(fil):
@@ -126,39 +129,8 @@ def _create_filter(query: Query, fil: Dict[str, Any]) -> Query:
             "Operator 'match' shouldn't be used with relations"
         )
 
-    if _is_ltree_op(fil):
-        op = fil["operation"]
-        subquery = (
-            query.with_entities(model.path)
-            .filter(model.id == value)
-            .subquery()
-        )
-
-        if op == "parent":
-            return (
-                query.filter(
-                    func.subpath(
-                        model.path, 0, func.nlevel(subquery.c.path) - 1
-                    )
-                    == model.path,
-                    func.index(subquery.c.path, model.path) != -1,
-                )
-                .order_by(model.path.desc())
-                .limit(1)
-            )
-        elif op == "parents_recursive":
-            return query.filter(
-                func.nlevel(subquery.c.path) != func.nlevel(model.path),
-                func.index(subquery.c.path, model.path) != -1,
-            ).order_by(model.path)
-        elif op == "children":
-            return query.filter(
-                func.nlevel(model.path) == func.nlevel(subquery.c.path) + 1
-            ).order_by(model.path)
-        elif op == "children_recursive":
-            return query.filter(
-                func.nlevel(model.path) > func.nlevel(subquery.c.path)
-            ).order_by(model.path)
+    if isinstance(getattr(model, field).type, LtreeType):
+        return _make_ltree_query(query=query, model=model, op=op, value=value)
 
     if _op_is_match(fil):
         column = _get_column(model, field)
@@ -216,15 +188,58 @@ def _op_is_not(fil: Dict[str, str]) -> bool:
     return op == "ne" or op == "not_in" or op == "not_ilike"
 
 
-def _is_ltree_op(fil: Dict[str, str]) -> bool:
-    op = fil.get("op")
+def _make_ltree_query(
+    query: Query, model: Type[DeclarativeMeta], op: str, value: int
+) -> Query:
+    """
+    Makes query for LTREE field.
+    Passes through income query if operation is not supported.
 
-    return op in (
-        "parent",
-        "parents_recursive",
-        "children",
-        "children_recursive",
+    Supported operations:
+    - "parent" - return parent of record with provided id
+    - "parents_recursive" - return all ancestors of record with provided id
+    - "children" - get first-level children for record with provided id
+    - "children_recursive" - get all descendants for record with provided id
+
+    :param query: Initial model's query
+    :param model: Model class
+    :param op: Operation name
+    :param value: Id of record
+    :return: Query instance
+    """
+    subquery = (
+        query.with_entities(model.path).filter(model.id == value).subquery()
     )
+
+    if op == "parent":
+        return (
+            query.filter(
+                (
+                    func.subpath(
+                        model.path, 0, func.nlevel(subquery.c.path) - 1
+                    )
+                    == model.path
+                ),
+                func.index(subquery.c.path, model.path) != -1,
+            )
+            .order_by(model.path.desc())
+            .limit(1)
+        )
+    elif op == "parents_recursive":
+        return query.filter(
+            func.nlevel(subquery.c.path) != func.nlevel(model.path),
+            func.index(subquery.c.path, model.path) != -1,
+        ).order_by(model.path)
+    elif op == "children":
+        return query.filter(
+            func.nlevel(model.path) == func.nlevel(subquery.c.path) + 1
+        ).order_by(model.path)
+    elif op == "children_recursive":
+        return query.filter(
+            func.nlevel(model.path) > func.nlevel(subquery.c.path)
+        ).order_by(model.path)
+
+    return query
 
 
 def _create_or_condition(

--- a/lib/filter_lib/src/schema_generator.py
+++ b/lib/filter_lib/src/schema_generator.py
@@ -34,6 +34,10 @@ class _FilterOperations(str, enum.Enum):
     NOT_ANY = "not_any"
     MATCH = "match"
     DISTINCT = "distinct"
+    PARENT = "parent"
+    PARENTS_RECURSIVE = "parents_recursive"
+    CHILDREN = "children"
+    CHILDREN_RECURSIVE = "children_recursive"
 
 
 class _FilterPagesize(enum.IntEnum):

--- a/lib/filter_lib/tests/conftest.py
+++ b/lib/filter_lib/tests/conftest.py
@@ -4,7 +4,13 @@ import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
 
+from sqlalchemy_utils import LtreeType
+
+from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
+
 Base = declarative_base()
+
+SQLiteTypeCompiler.visit_LTREE = lambda *args, **kwargs: "LTREE"
 
 
 class User(Base):
@@ -14,6 +20,7 @@ class User(Base):
     name = sa.Column(sa.String)
     email = sa.Column(sa.String)
     addresses = relationship("Address", back_populates="user")
+    path = sa.Column(LtreeType, nullable=False)
 
 
 class Address(Base):

--- a/lib/filter_lib/tests/conftest.py
+++ b/lib/filter_lib/tests/conftest.py
@@ -20,7 +20,6 @@ class User(Base):
     name = sa.Column(sa.String)
     email = sa.Column(sa.String)
     addresses = relationship("Address", back_populates="user")
-    path = sa.Column(LtreeType, nullable=False)
 
 
 class Address(Base):
@@ -30,6 +29,13 @@ class Address(Base):
     location = sa.Column(sa.String)
     owner = sa.Column(sa.Integer, sa.ForeignKey("users.id", use_alter=True))
     user = relationship("User", back_populates="addresses")
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
+    path = sa.Column(LtreeType, nullable=False)
 
 
 @pytest.fixture(scope="function")

--- a/lib/filter_lib/tests/conftest.py
+++ b/lib/filter_lib/tests/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.sqlite.base import SQLiteTypeCompiler
 
 Base = declarative_base()
 
+# Monkey-patching visit operation not supported by SQLite
 SQLiteTypeCompiler.visit_LTREE = lambda *args, **kwargs: "LTREE"
 
 

--- a/lib/filter_lib/tests/test_query_modifier.py
+++ b/lib/filter_lib/tests/test_query_modifier.py
@@ -168,6 +168,32 @@ def test_create_filter_ltree_children_recursive(get_session):
     assert compiled_statement.params == {"id_1": 2}
 
 
+def test_create_filter_ltree_not_supported_operation(get_session):
+    # Arrange
+    session = get_session
+
+    query = session.query(Category)
+    spec = {
+        "model": "Category",
+        "field": "path",
+        "op": "not_supported_operation",
+        "value": 2,
+    }
+
+    # Act
+    query = _create_filter(query, spec)
+
+    expected_sql_str = (
+        "SELECT categories.id, categories.path \nFROM categories"
+    )
+
+    compiled_statement = query.statement.compile()
+
+    # Assert
+    assert str(compiled_statement) == expected_sql_str
+    assert compiled_statement.params == {}
+
+
 def test_form_query(get_session):
     session = get_session
     user_1 = User(id=5, name="user")

--- a/lib/filter_lib/tests/test_query_modifier.py
+++ b/lib/filter_lib/tests/test_query_modifier.py
@@ -1,11 +1,11 @@
-from .conftest import User, Address
+from .conftest import User, Address, Category
 from ..src.query_modificator import (
     _get_entity,
     _get_column,
     _create_filter,
     form_query,
     _op_is_not,
-    _create_or_condition
+    _create_or_condition,
 )
 from ..src.enum_generator import get_enum_from_orm
 
@@ -34,6 +34,138 @@ def test_create_filter(get_session):
     spec = {"model": "User", "field": "name", "op": "eq", "value": "test_one"}
     query = _create_filter(query, spec)
     assert len(query.all()) == 1
+
+
+def test_create_filter_ltree_parent(get_session):
+    # Arrange
+    session = get_session
+
+    query = session.query(Category)
+    spec = {"model": "Category", "field": "path", "op": "parent", "value": 2}
+
+    # Act
+    query = _create_filter(query, spec)
+
+    expected_sql_str = (
+        "SELECT categories.id, categories.path \n"
+        "FROM categories, "
+        "(SELECT categories.path AS path \n"
+        "FROM categories \n"
+        "WHERE categories.id = :id_1) AS anon_1 \n"
+        "WHERE subpath(categories.path, :subpath_1, nlevel(anon_1.path) - :nlevel_1) = categories.path "
+        "AND index(anon_1.path, categories.path) != :index_1 "
+        "ORDER BY categories.path DESC\n"
+        " LIMIT :param_1"
+    )
+
+    compiled_statement = query.statement.compile()
+
+    # Assert
+    assert str(compiled_statement) == expected_sql_str
+    assert compiled_statement.params == {
+        "id_1": 2,
+        "subpath_1": 0,
+        "nlevel_1": 1,
+        "index_1": -1,
+        "param_1": 1,
+    }
+
+
+def test_create_filter_ltree_parents_recursive(get_session):
+    # Arrange
+    session = get_session
+
+    query = session.query(Category)
+    spec = {
+        "model": "Category",
+        "field": "path",
+        "op": "parents_recursive",
+        "value": 2,
+    }
+
+    # Act
+    query = _create_filter(query, spec)
+
+    expected_sql_str = (
+        "SELECT categories.id, categories.path \n"
+        "FROM categories, "
+        "(SELECT categories.path AS path \n"
+        "FROM categories \n"
+        "WHERE categories.id = :id_1) AS anon_1 \n"
+        "WHERE nlevel(anon_1.path) != nlevel(categories.path) "
+        "AND index(anon_1.path, categories.path) != :index_1 "
+        "ORDER BY categories.path"
+    )
+
+    compiled_statement = query.statement.compile()
+
+    # Assert
+    assert str(compiled_statement) == expected_sql_str
+    assert compiled_statement.params == {"id_1": 2, "index_1": -1}
+
+
+def test_create_filter_ltree_children(get_session):
+    # Arrange
+    session = get_session
+
+    query = session.query(Category)
+    spec = {
+        "model": "Category",
+        "field": "path",
+        "op": "children",
+        "value": 2,
+    }
+
+    # Act
+    query = _create_filter(query, spec)
+
+    expected_sql_str = (
+        "SELECT categories.id, categories.path \n"
+        "FROM categories, "
+        "(SELECT categories.path AS path \n"
+        "FROM categories \n"
+        "WHERE categories.id = :id_1) AS anon_1 \n"
+        "WHERE nlevel(categories.path) = nlevel(anon_1.path) + :nlevel_1 "
+        "ORDER BY categories.path"
+    )
+
+    compiled_statement = query.statement.compile()
+
+    # Assert
+    assert str(compiled_statement) == expected_sql_str
+    assert compiled_statement.params == {"id_1": 2, "nlevel_1": 1}
+
+
+def test_create_filter_ltree_children_recursive(get_session):
+    # Arrange
+    session = get_session
+
+    query = session.query(Category)
+    spec = {
+        "model": "Category",
+        "field": "path",
+        "op": "children_recursive",
+        "value": 2,
+    }
+
+    # Act
+    query = _create_filter(query, spec)
+
+    expected_sql_str = (
+        "SELECT categories.id, categories.path \n"
+        "FROM categories, "
+        "(SELECT categories.path AS path \n"
+        "FROM categories \n"
+        "WHERE categories.id = :id_1) AS anon_1 \n"
+        "WHERE nlevel(categories.path) > nlevel(anon_1.path) "
+        "ORDER BY categories.path"
+    )
+
+    compiled_statement = query.statement.compile()
+
+    # Assert
+    assert str(compiled_statement) == expected_sql_str
+    assert compiled_statement.params == {"id_1": 2}
 
 
 def test_form_query(get_session):
@@ -196,7 +328,12 @@ def test_form_query_with_distincts_and_filters_and_sorting(get_session):
 def test_op_is_not_positive():
     fil1 = {"model": "User", "field": "name", "op": "ne", "value": "123"}
     fil2 = {"model": "User", "field": "name", "op": "not_in", "value": ["123"]}
-    fil3 = {"model": "User", "field": "name", "op": "not_ilike", "value": "123"}
+    fil3 = {
+        "model": "User",
+        "field": "name",
+        "op": "not_ilike",
+        "value": "123",
+    }
     assert _op_is_not(fil1)
     assert _op_is_not(fil2)
     assert _op_is_not(fil3)
@@ -216,24 +353,54 @@ def test_op_is_not_negative():
 def test_create_or_condition():
     fil1 = {"model": "User", "field": "name", "op": "ne", "value": "123"}
     fil2 = {"model": "User", "field": "name", "op": "not_in", "value": ["123"]}
-    fil3 = {"model": "User", "field": "name", "op": "not_ilike", "value": "123"}
+    fil3 = {
+        "model": "User",
+        "field": "name",
+        "op": "not_ilike",
+        "value": "123",
+    }
 
     assert _create_or_condition(fil1) == {
         "or": [
             {"model": "User", "field": "name", "op": "ne", "value": "123"},
-            {"model": "User", "field": "name", "op": "is_null", "value": "123"}
+            {
+                "model": "User",
+                "field": "name",
+                "op": "is_null",
+                "value": "123",
+            },
         ]
     }
     assert _create_or_condition(fil2) == {
         "or": [
-            {"model": "User", "field": "name", "op": "not_in", "value": ["123"]},
-            {"model": "User", "field": "name", "op": "is_null", "value": ["123"]}
+            {
+                "model": "User",
+                "field": "name",
+                "op": "not_in",
+                "value": ["123"],
+            },
+            {
+                "model": "User",
+                "field": "name",
+                "op": "is_null",
+                "value": ["123"],
+            },
         ]
     }
     assert _create_or_condition(fil3) == {
         "or": [
-            {"model": "User", "field": "name", "op": "not_ilike", "value": "123"},
-            {"model": "User", "field": "name", "op": "is_null", "value": "123"}
+            {
+                "model": "User",
+                "field": "name",
+                "op": "not_ilike",
+                "value": "123",
+            },
+            {
+                "model": "User",
+                "field": "name",
+                "op": "is_null",
+                "value": "123",
+            },
         ]
     }
 


### PR DESCRIPTION
* Add support of LTREE (Postgre-only) operations:
  * "parent" - return parent of record with provided id
  * "parents_recursive" - return all ancestors of record with provided id
  * "children" - get first-level children for record with provided id
  * "children_recursive" - get all descendants for record with provided id
* Add tests to cover this operations. Tests are checking sql statements for now because SQLite doesn't support LTREE data type
* Minor style fixes