### PR TITLE
fix: special symbols in category id

### DIFF
--- a/annotation/app/categories/services.py
+++ b/annotation/app/categories/services.py
@@ -49,7 +49,7 @@ def add_category_db(
         tree = Ltree(f'{category_input.id}')
 
     category = Category(
-        id=(id_ or str(uuid.uuid4())),
+        id=(id_ or str(uuid.uuid4()).replace('-', '')),
         name=name,
         tenant=tenant,
         parent=parent if parent != "null" else None,

--- a/annotation/app/categories/services.py
+++ b/annotation/app/categories/services.py
@@ -49,7 +49,7 @@ def add_category_db(
         tree = Ltree(f'{category_input.id}')
 
     category = Category(
-        id=(id_ or str(uuid.uuid4()).replace('-', '')),
+        id=(id_ or uuid.uuid4().hex),
         name=name,
         tenant=tenant,
         parent=parent if parent != "null" else None,

--- a/annotation/app/categories/services.py
+++ b/annotation/app/categories/services.py
@@ -81,6 +81,14 @@ def fetch_category_children(db: Session, category_input: Category) -> List[Categ
     ).offset(1).all()
 
 
+def has_children(db: Session, category_input: Category) -> bool:
+    return bool(
+        db.query(Category.id).filter(
+            Category.tree.descendant_of(category_input.tree)
+        ).offset(1).first()
+    )
+
+
 def check_unique_category_field(
     db: Session, value: str, field: str, tenant: str
 ) -> None:
@@ -260,7 +268,7 @@ def insert_category_tree(
     db: Session, category_db: Category
 ) -> CategoryResponseSchema:
     parents = fetch_category_parents(db, category_db)
-    children = fetch_category_children(db, category_db)
+    has_descendants = has_children(db, category_db)
 
     category_response = response_object_from_db(category_db)
 
@@ -268,7 +276,5 @@ def insert_category_tree(
         category_response.parents = [
             response_object_from_db(category) for category in parents
         ]
-    category_response.children = [
-        response_object_from_db(category) for category in children
-    ]
+    category_response.has_children = has_descendants
     return category_response

--- a/annotation/app/models.py
+++ b/annotation/app/models.py
@@ -129,7 +129,7 @@ class Category(Base):
 
     @validates("id")
     def validate_id(self, key, id_):
-        if id_ and not id_.replace('_', '').isalnum():
+        if not id_.replace('_', '').isalnum():
             raise CheckFieldError(f'Category id must be alphanumeric.')
         return id_
 

--- a/annotation/app/models.py
+++ b/annotation/app/models.py
@@ -11,10 +11,11 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, ENUM, JSON, JSONB, UUID
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, validates
 from sqlalchemy_utils import LtreeType
 
 from app.database import Base
+from app.errors import CheckFieldError
 from app.schemas import (
     DEFAULT_LOAD,
     CategoryTypeSchema,
@@ -123,8 +124,14 @@ class Category(Base):
     )
     tree = Column(LtreeType, nullable=True)
     __table_args__ = (
-        Index('index_tree', tree, postgresql_using="gist"),
+        Index("index_tree", tree, postgresql_using="gist"),
     )
+
+    @validates("id")
+    def validate_id(self, key, id_):
+        if id_ and not id_.replace('_', '').isalnum():
+            raise CheckFieldError(f'Category id must be alphanumeric.')
+        return id_
 
 
 class User(Base):

--- a/annotation/app/schemas/categories.py
+++ b/annotation/app/schemas/categories.py
@@ -1,8 +1,9 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
+from app.errors import CheckFieldError
 
 class CategoryTypeSchema(str, Enum):
     box = "box"
@@ -27,6 +28,12 @@ class CategoryInputSchema(CategoryBaseSchema):
         example="my_category",
         description="If id is not provided, generates it as a UUID.",
     )
+
+    @validator('id')
+    def alphanumeric_validator(cls, value):
+        if value and not value.isalnum():
+            raise CheckFieldError(f'Category id must be alphanumeric.')
+        return value
 
 
 class SubCategoriesOutSchema(BaseModel):

--- a/annotation/app/schemas/categories.py
+++ b/annotation/app/schemas/categories.py
@@ -31,7 +31,7 @@ class CategoryInputSchema(CategoryBaseSchema):
 
     @validator('id')
     def alphanumeric_validator(cls, value):
-        if value and not value.isalnum():
+        if value and not value.replace('_', '').isalnum():
             raise CheckFieldError(f'Category id must be alphanumeric.')
         return value
 

--- a/annotation/app/schemas/categories.py
+++ b/annotation/app/schemas/categories.py
@@ -51,7 +51,7 @@ class CategoryORMSchema(CategoryInputSchema):
 
 class CategoryResponseSchema(CategoryInputSchema):
     parents: List[dict] = Field(default=[])
-    children: List[dict] = Field(default=[])
+    has_children: Optional[bool] = Field(default=None)
 
     class Config:
         allow_population_by_field_name = True

--- a/annotation/documentation/openapi.yaml
+++ b/annotation/documentation/openapi.yaml
@@ -2358,12 +2358,9 @@ components:
           items:
             type: object
           default: []
-        children:
-          title: Children
-          type: array
-          items:
-            type: object
-          default: []
+        has_children:
+          title: Has Children
+          type: boolean
     CategoryTypeSchema:
       title: CategoryTypeSchema
       enum:

--- a/annotation/tests/test_category_crud.py
+++ b/annotation/tests/test_category_crud.py
@@ -166,7 +166,7 @@ def test_add_db_connection_error(prepare_db_categories_different_names):
     ["category_id", "category_name"],
     [  # this tenant and common category already exist names
         (None, "Title"),
-        ("my_favourite_category", "Table"),  # unique id
+        ("MyFavouriteCategory", "Table"),  # unique id
     ],
 )
 def test_add_already_exist_category_name(
@@ -284,7 +284,7 @@ def test_add_id_already_exists(prepare_db_categories_different_names):
 
 @mark.integration
 def test_add_id_is_unique(prepare_db_categories_different_names):
-    data = prepare_category_body(id_="my_favourite_category")
+    data = prepare_category_body(id_="MyFavouriteCategory")
     response = client.post(CATEGORIES_PATH, json=data, headers=TEST_HEADERS)
     assert response.status_code == 201
     assert (
@@ -295,11 +295,26 @@ def test_add_id_is_unique(prepare_db_categories_different_names):
 
 
 @mark.integration
+@mark.parametrize(
+    "category_id",
+    ("1st!-category1", "2nd%category", "3rd_category"),
+)
+def test_add_id_special_chars(
+    category_id,
+    prepare_db_categories_different_names
+):
+    data = prepare_category_body(id_=category_id)
+    response = client.post(CATEGORIES_PATH, json=data, headers=TEST_HEADERS)
+    assert response.status_code == 400
+    assert "Category id must be alphanumeric" in response.text
+
+
+@mark.integration
 @patch("uuid.uuid4", return_value="fe857daa-8332-4a26-ab50-29be0a74477e")
 def test_add_id_is_generated(prepare_db_categories_different_names):
     data = prepare_category_body()
     response = client.post(CATEGORIES_PATH, json=data, headers=TEST_HEADERS)
-    mocked_id = str(uuid.uuid4())
+    mocked_id = str(uuid.uuid4()).replace('-', '')
     data_with_mocked_id = prepare_category_body(id_=mocked_id)
     assert response.status_code == 201
     assert (

--- a/annotation/tests/test_delete_batch_tasks.py
+++ b/annotation/tests/test_delete_batch_tasks.py
@@ -23,7 +23,7 @@ DELETE_BATCH_TASKS_ANNOTATOR = User(
 )
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     )

--- a/annotation/tests/test_finish_task.py
+++ b/annotation/tests/test_finish_task.py
@@ -33,7 +33,7 @@ client = TestClient(app)
 
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     )

--- a/annotation/tests/test_get_job.py
+++ b/annotation/tests/test_get_job.py
@@ -28,7 +28,7 @@ JOB_TEST_ANNOTATORS = (
     User(user_id="ef81a4d0-cc01-447b-9025-a70ed441672d"),
     User(user_id="2d3a59c3-c0e8-4322-82df-e693106c1cd0"),
 )
-CATEGORIES = [Category(id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5", name="Test")]
+CATEGORIES = [Category(id="18d3d189e73a4680bfa77ba3fe6ebee5", name="Test")]
 FILE_TEST_IDS = [
     1,
     2,

--- a/annotation/tests/test_get_job_files.py
+++ b/annotation/tests/test_get_job_files.py
@@ -23,7 +23,7 @@ client = TestClient(app)
 GET_JOB_FILES_PATH = "/jobs/{job_id}/files"
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),

--- a/annotation/tests/test_get_job_progress.py
+++ b/annotation/tests/test_get_job_progress.py
@@ -25,7 +25,7 @@ JOB_TEST_PROGRESS_ANNOTATORS = (
 )
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     )

--- a/annotation/tests/test_get_revisions_without_annotation.py
+++ b/annotation/tests/test_get_revisions_without_annotation.py
@@ -33,7 +33,7 @@ REV_WITHOUT_ANNOTATION_ANNOTATOR = User(
 )
 REV_WITHOUT_ANNOTATION_CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),

--- a/annotation/tests/test_job_categories.py
+++ b/annotation/tests/test_job_categories.py
@@ -70,7 +70,7 @@ def prepare_get_result(
         category = prepare_category_body(name=cat_name)
         category["id"] = cat_id
         category['parents'] = []
-        category['children'] = []
+        category['has_children'] = False
         categories.append(category)
     body = {
         "pagination": {
@@ -128,10 +128,10 @@ def prepare_expected_result(
 
 
 def prepare_category_response(
-    data: dict, parents: List[dict] = [], children: List[dict] = []
+    data: dict, parents: List[dict] = [], has_children: Optional[bool] = None
 ) -> dict:
     data['parents'] = parents
-    data['children'] = children
+    data['has_children'] = has_children
     return data
 
 
@@ -504,7 +504,10 @@ def test_search_allowed_categories(
     )
     category = response.json()["data"][0]
     assert response.status_code == 200
-    assert prepare_expected_result(category) == prepare_category_response(expected)
+    assert (
+        prepare_category_response(expected, has_children=False)
+        == prepare_expected_result(category)
+    )
 
 
 @mark.integration

--- a/annotation/tests/test_post.py
+++ b/annotation/tests/test_post.py
@@ -25,7 +25,7 @@ TEST_POST_USERS = [
 ]
 POST_TASKS_CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),

--- a/annotation/tests/test_post_annotation.py
+++ b/annotation/tests/test_post_annotation.py
@@ -63,7 +63,7 @@ client = TestClient(app)
 
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),

--- a/annotation/tests/test_post_next_task.py
+++ b/annotation/tests/test_post_next_task.py
@@ -33,7 +33,7 @@ client = TestClient(app)
 POST_NEXT_TASK_PATH = "/tasks/next"
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),

--- a/annotation/tests/test_start_job.py
+++ b/annotation/tests/test_start_job.py
@@ -23,7 +23,7 @@ client = TestClient(app)
 START_JOB_PATH = "/jobs/{job_id}/start"
 CATEGORIES = [
     Category(
-        id="aeacb631-672e-4b04-8b42-ed76f0ede2c5",
+        id="aeacb631672e4b048b42ed76f0ede2c5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),

--- a/annotation/tests/test_tasks_crud_cr.py
+++ b/annotation/tests/test_tasks_crud_cr.py
@@ -21,7 +21,7 @@ client = TestClient(app)
 
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),

--- a/annotation/tests/test_tasks_crud_ud.py
+++ b/annotation/tests/test_tasks_crud_ud.py
@@ -36,7 +36,7 @@ CRUD_UD_FILE_2 = File(
 )
 CATEGORIES = [
     Category(
-        id="18d3d189-e73a-4680-bfa7-7ba3fe6ebee5",
+        id="18d3d189e73a4680bfa77ba3fe6ebee5",
         name="Test",
         type=CategoryTypeSchema.box,
     ),


### PR DESCRIPTION
Issue: #2

Fixed 500 Internal server error on creating `Category` with _id_ containing special chars such as "-", "!", "." etc.
Added validator, now only alphanumeric are allowed.
Added tests for such cases and also fixed existed ones.

Edit:
Allowed underscore "_".
Replaced 'parents' list attribute with the 'has_children' bool value in Category response.
Updated openapi.yaml