### PR TITLE
hotfix: isort query_modificator

### DIFF
--- a/lib/filter_lib/src/query_modificator.py
+++ b/lib/filter_lib/src/query_modificator.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.query import Query
 from sqlalchemy_filters import apply_filters, apply_sort
 from sqlalchemy_filters.exceptions import BadFilterFormat, BadSpec
-
 from sqlalchemy_utils import LtreeType
 
 from .pagination import PaginationParams, make_pagination


### PR DESCRIPTION
Just run isort against `lib/filter_lib/src/query_modificator.py` 