### PR TITLE
fix: filter_lib children bug

### DIFF
--- a/lib/filter_lib/src/query_modificator.py
+++ b/lib/filter_lib/src/query_modificator.py
@@ -231,12 +231,14 @@ def _make_ltree_query(
         ).order_by(model.tree)
     elif op == "children":
         return query.filter(
-            func.nlevel(model.tree) == func.nlevel(subquery.c.tree) + 1
-        ).order_by(model.tree)
+            model.tree.op("<@")(subquery.c.tree),
+            func.nlevel(model.tree) == func.nlevel(subquery.c.tree) + 1,
+        )
     elif op == "children_recursive":
         return query.filter(
-            func.nlevel(model.tree) > func.nlevel(subquery.c.tree)
-        ).order_by(model.tree)
+            model.tree.op("<@")(subquery.c.tree),
+            func.nlevel(model.tree) > func.nlevel(subquery.c.tree),
+        )
 
     return query
 


### PR DESCRIPTION
Fixed bug when filter_lib operators 'children_recursive' and 'children' returned corresponding siblings instead of direct children.