### PR TITLE
feat: documents pair classification

### DIFF
--- a/annotation/alembic/versions/6fb3e0d231ff_create_document_links_table.py
+++ b/annotation/alembic/versions/6fb3e0d231ff_create_document_links_table.py
@@ -1,0 +1,64 @@
+"""create document links table
+
+Revision ID: 6fb3e0d231ff
+Revises: f1a58d769aa2
+Create Date: 2022-12-27 15:24:53.927511
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6fb3e0d231ff"
+down_revision = "f1a58d769aa2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "document_links",
+        sa.Column("original_revision", sa.VARCHAR),
+        sa.Column("original_file_id", sa.INTEGER),
+        sa.Column("original_job_id", sa.INTEGER),
+        sa.Column("similar_revision", sa.VARCHAR),
+        sa.Column("similar_file_id", sa.INTEGER),
+        sa.Column("similar_job_id", sa.INTEGER),
+        sa.Column(
+            "label",
+            sa.VARCHAR,
+            sa.ForeignKey("categories.id", ondelete="SET NULL"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ("original_revision", "original_file_id", "original_job_id"),
+            (
+                "annotated_docs.revision",
+                "annotated_docs.file_id",
+                "annotated_docs.job_id",
+            ),
+            ondelete="cascade",
+        ),
+        sa.ForeignKeyConstraint(
+            ("similar_revision", "similar_file_id", "similar_job_id"),
+            (
+                "annotated_docs.revision",
+                "annotated_docs.file_id",
+                "annotated_docs.job_id",
+            ),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint(
+            "original_revision",
+            "original_file_id",
+            "original_job_id",
+            "similar_revision",
+            "similar_file_id",
+            "similar_job_id",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("document_links")

--- a/annotation/alembic/versions/8ea2ff0fea64_create_association_doc_category_table.py
+++ b/annotation/alembic/versions/8ea2ff0fea64_create_association_doc_category_table.py
@@ -1,0 +1,43 @@
+"""create association_doc_category table
+
+Revision ID: 8ea2ff0fea64
+Revises: 6fb3e0d231ff
+Create Date: 2022-12-27 15:56:43.667409
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8ea2ff0fea64"
+down_revision = "6fb3e0d231ff"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "association_doc_category",
+        sa.Column("revision", sa.VARCHAR, primary_key=True),
+        sa.Column("file_id", sa.INTEGER, primary_key=True),
+        sa.Column("job_id", sa.INTEGER, primary_key=True),
+        sa.Column(
+            "category_id",
+            sa.VARCHAR,
+            sa.ForeignKey("categories.id"),
+            primary_key=True,
+        ),
+        sa.ForeignKeyConstraint(
+            ("revision", "file_id", "job_id"),
+            (
+                "annotated_docs.revision",
+                "annotated_docs.file_id",
+                "annotated_docs.job_id",
+            ),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("association_doc_category")

--- a/annotation/app/annotations/resources.py
+++ b/annotation/app/annotations/resources.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from tenant_dependency import TenantData
 
 from app.database import get_db
-from app.errors import NoSuchRevisionsError
+from app.errors import NoSuchCategoryError, NoSuchRevisionsError
 from app.microservice_communication.assets_communication import (
     get_file_path_and_bucket,
 )
@@ -209,6 +209,11 @@ def post_annotation_by_user(
             status_code=404,
             detail=f"Cannot assign similar documents: {err}",
         ) from err
+    except NoSuchCategoryError as err:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Cannot assign categories to document: {err}",
+        ) from err
     check_if_kafka_message_is_needed(
         db,
         latest_doc,
@@ -300,6 +305,11 @@ def post_annotation_by_pipeline(
         raise HTTPException(
             status_code=404,
             detail=f"Cannot assign similar documents: {err}",
+        ) from err
+    except NoSuchCategoryError as err:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Cannot assign categories to document: {err}",
         ) from err
     check_if_kafka_message_is_needed(
         db,

--- a/annotation/app/models.py
+++ b/annotation/app/models.py
@@ -81,6 +81,24 @@ association_job_category = Table(
     Column("category_id", ForeignKey("categories.id"), primary_key=True),
     Column("job_id", ForeignKey("jobs.job_id"), primary_key=True),
 )
+association_doc_category = Table(
+    "association_doc_category",
+    Base.metadata,
+    Column("revision", VARCHAR, primary_key=True),
+    Column("file_id", INTEGER, primary_key=True),
+    Column("job_id", INTEGER, primary_key=True),
+    Column(
+        "category_id", VARCHAR, ForeignKey("categories.id"), primary_key=True
+    ),
+    ForeignKeyConstraint(
+        ("revision", "file_id", "job_id"),
+        (
+            "annotated_docs.revision",
+            "annotated_docs.file_id",
+            "annotated_docs.job_id",
+        ),
+    ),
+)
 
 
 class AnnotatedDoc(Base):
@@ -121,6 +139,7 @@ class AnnotatedDoc(Base):
         "DocumentLinks.original_file_id, "
         "DocumentLinks.original_job_id]",
     )
+    categories = relationship("Category", secondary=association_doc_category)
 
     def __repr__(self) -> str:
         return (

--- a/annotation/app/models.py
+++ b/annotation/app/models.py
@@ -10,7 +10,9 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
+    PrimaryKeyConstraint,
     Table,
     func,
 )
@@ -85,13 +87,13 @@ class AnnotatedDoc(Base):
     __tablename__ = "annotated_docs"
 
     revision = Column(VARCHAR, primary_key=True)
+    file_id = Column(INTEGER, primary_key=True)
+    job_id = Column(INTEGER, primary_key=True)
     user = Column(
         UUID(as_uuid=True), ForeignKey("users.user_id", ondelete="SET NULL")
     )
     pipeline = Column(INTEGER)
     date = Column(TIMESTAMP, server_default=func.now(), nullable=False)
-    file_id = Column(INTEGER, primary_key=True)
-    job_id = Column(INTEGER, primary_key=True)
     pages = Column(JSON, nullable=False, server_default="{}")
     failed_validation_pages = Column(
         ARRAY(INTEGER), nullable=False, server_default="{}"
@@ -101,6 +103,32 @@ class AnnotatedDoc(Base):
     task_id = Column(INTEGER, ForeignKey("tasks.id", ondelete="SET NULL"))
 
     tasks = relationship("ManualAnnotationTask", back_populates="docs")
+    similar_docs = relationship(
+        "AnnotatedDoc",
+        secondary="document_links",
+        primaryjoin="and_("
+        "AnnotatedDoc.revision==DocumentLinks.original_revision,"
+        "AnnotatedDoc.file_id==DocumentLinks.original_file_id,"
+        "AnnotatedDoc.job_id==DocumentLinks.original_job_id)",
+        secondaryjoin="and_("
+        "AnnotatedDoc.revision==DocumentLinks.similar_revision,"
+        "AnnotatedDoc.file_id==DocumentLinks.similar_file_id,"
+        "AnnotatedDoc.job_id==DocumentLinks.similar_job_id)",
+    )
+    links = relationship(
+        "DocumentLinks",
+        foreign_keys="[DocumentLinks.original_revision, "
+        "DocumentLinks.original_file_id, "
+        "DocumentLinks.original_job_id]",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            "<AnnotatedDoc("
+            f"revision={self.revision!r}, "
+            f"file_id={self.file_id!r}, "
+            f"job_id={self.job_id!r})>"
+        )
 
 
 def default_tree(column_name: str) -> Callable[..., Ltree]:
@@ -295,7 +323,6 @@ class AnnotationStatistics(Base):
     def to_dict(self) -> dict:
         return {
             "task_id": self.task_id,
-            "event_date": self.event_date,
             "event_type": self.event_type,
             "additional_data": self.additional_data,
         }
@@ -332,3 +359,62 @@ class AgreementScore(Base):
             "time_finish": self.task.stats.updated,
             "agreement_score": self.agreement_score,
         }
+
+
+class DocumentLinks(Base):
+    __tablename__ = "document_links"
+
+    original_revision = Column(VARCHAR)
+    original_file_id = Column(INTEGER)
+    original_job_id = Column(INTEGER)
+
+    similar_revision = Column(VARCHAR)
+    similar_file_id = Column(INTEGER)
+    similar_job_id = Column(INTEGER)
+
+    label = Column(
+        VARCHAR,
+        ForeignKey("categories.id", ondelete="SET NULL"),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            (original_revision, original_file_id, original_job_id),
+            (AnnotatedDoc.revision, AnnotatedDoc.file_id, AnnotatedDoc.job_id),
+            ondelete="cascade",
+        ),
+        ForeignKeyConstraint(
+            (similar_revision, similar_file_id, similar_job_id),
+            (AnnotatedDoc.revision, AnnotatedDoc.file_id, AnnotatedDoc.job_id),
+            ondelete="cascade",
+        ),
+        PrimaryKeyConstraint(
+            original_revision,
+            original_file_id,
+            original_job_id,
+            similar_revision,
+            similar_file_id,
+            similar_job_id,
+        ),
+    )
+    original_doc = relationship(
+        "AnnotatedDoc",
+        foreign_keys=[original_revision, original_file_id, original_job_id],
+    )
+    similar_doc = relationship(
+        "AnnotatedDoc",
+        foreign_keys=[similar_revision, similar_file_id, similar_job_id],
+    )
+
+    def __repr__(self) -> str:
+        return (
+            "<DocumentLinks("
+            f"original_revision={self.original_revision}, "
+            f"original_file_id={self.original_file_id}, "
+            f"original_job_id={self.original_job_id}, "
+            f"similar_revision={self.similar_revision}, "
+            f"similar_file_id={self.similar_file_id}, "
+            f"similar_job_id={self.similar_job_id}, "
+            f"label={self.label})>"
+        )

--- a/annotation/app/schemas/__init__.py
+++ b/annotation/app/schemas/__init__.py
@@ -4,6 +4,7 @@ from app.schemas.annotations import (
     PageOutSchema,
     PageSchema,
     ParticularRevisionSchema,
+    RevisionLink,
 )
 from app.schemas.categories import (
     CategoryBaseSchema,
@@ -70,6 +71,7 @@ __all__ = [
     PageOutSchema,
     PageSchema,
     ParticularRevisionSchema,
+    RevisionLink,
     CategoryBaseSchema,
     CategoryInputSchema,
     CategoryORMSchema,

--- a/annotation/app/schemas/annotations.py
+++ b/annotation/app/schemas/annotations.py
@@ -76,10 +76,8 @@ class ParticularRevisionSchema(BaseModel):
     failed_validation_pages: Optional[List[int]] = Field(
         None, ge=1, example=[]
     )
-    categories: Optional[List[str]] = Field(
-        None, example=["science", "manifest"]
-    )
     similar_revisions: Optional[List[RevisionLink]] = Field(None)
+    categories: Optional[List[str]] = Field(None, example=["1", "2"])
 
 
 class DocForSaveSchema(BaseModel):
@@ -95,10 +93,8 @@ class DocForSaveSchema(BaseModel):
     failed_validation_pages: Optional[Set[int]] = Field(
         None, ge=1, example={3, 4}
     )
-    categories: Optional[List[str]] = Field(
-        None, example=["science", "manifest"]
-    )
     similar_revisions: Optional[List[RevisionLink]] = Field(None)
+    categories: Optional[List[str]] = Field(None, example=["1", "2"])
 
     @root_validator
     def one_field_empty_other_filled_check(cls, values):
@@ -184,6 +180,7 @@ class AnnotatedDocSchema(BaseModel):
     tenant: str = Field(..., example="badger-doc")
     task_id: int = Field(None, example=2)
     similar_revisions: Optional[List[RevisionLink]] = Field(None)
+    categories: Optional[List[str]] = Field(None, example=["1", "2"])
 
     @classmethod
     def from_orm(cls, obj):
@@ -198,6 +195,8 @@ class AnnotatedDocSchema(BaseModel):
                 )
                 for link in links
             ]
+        if categories := obj.categories:
+            value.categories = [category.id for category in categories]
         return value
 
     class Config:

--- a/annotation/tests/test_get_accumulated_revisions.py
+++ b/annotation/tests/test_get_accumulated_revisions.py
@@ -10,7 +10,8 @@ from app.microservice_communication.search import (
     BEARER,
     HEADER_TENANT,
 )
-from app.models import AnnotatedDoc, User
+from app.models import AnnotatedDoc, Category, User
+from app.schemas import CategoryTypeSchema
 from tests.consts import ANNOTATION_PATH
 from tests.override_app_dependency import TEST_TOKEN, app
 from tests.test_post_annotation import POST_ANNOTATION_PG_DOC
@@ -56,6 +57,13 @@ DOCS = [
         validated=[3],
         failed_validation_pages=[4],
         tenant=TENANT,
+        categories=[
+            Category(
+                id="jurisdiction",
+                name="jurisdiction category",
+                type=CategoryTypeSchema.link,
+            ),
+        ],
     ),
     AnnotatedDoc(
         revision="2",
@@ -70,6 +78,13 @@ DOCS = [
         validated=[4],
         failed_validation_pages=[1],
         tenant=TENANT,
+        categories=[
+            Category(
+                id="medical",
+                name="medical category",
+                type=CategoryTypeSchema.link,
+            ),
+        ],
     ),
     AnnotatedDoc(
         revision="3",
@@ -85,6 +100,13 @@ DOCS = [
         validated=[5],
         failed_validation_pages=[],
         tenant=TENANT,
+        categories=[
+            Category(
+                id="technical",
+                name="technical category",
+                type=CategoryTypeSchema.link,
+            ),
+        ],
     ),
 ]
 
@@ -147,7 +169,7 @@ LATEST_WITH_ALL_PAGES = dict(
     ],
     validated=[3, 4, 5],
     failed_validation_pages=[1],
-    categories=["test_category_1", "test_category_2"],
+    categories=[cat.id for cat in DOCS[2].categories],
     similar_revisions=None,
 )
 
@@ -191,7 +213,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 ],
                 validated=[5],
                 failed_validation_pages=[1],
-                categories=["test_category_1", "test_category_2"],
+                categories=[cat.id for cat in DOCS[2].categories],
                 similar_revisions=None,
             ),
         ),
@@ -220,7 +242,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 ],
                 validated=[3],
                 failed_validation_pages=[4],
-                categories=["test_category_1", "test_category_2"],
+                categories=[cat.id for cat in DOCS[0].categories],
                 similar_revisions=None,
             ),
         ),
@@ -248,7 +270,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 ],
                 validated=[3],
                 failed_validation_pages=[],
-                categories=["test_category_1", "test_category_2"],
+                categories=[cat.id for cat in DOCS[0].categories],
                 similar_revisions=None,
             ),
         ),
@@ -277,7 +299,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 ],
                 validated=[3, 4],
                 failed_validation_pages=[1],
-                categories=["test_category_1", "test_category_2"],
+                categories=[cat.id for cat in DOCS[1].categories],
                 similar_revisions=None,
             ),
         ),
@@ -297,7 +319,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 pages=[],
                 validated=[],
                 failed_validation_pages=[],
-                categories=["test_category_1", "test_category_2"],
+                categories=[cat.id for cat in DOCS[1].categories],
                 similar_revisions=None,
             ),
         ),
@@ -353,12 +375,6 @@ def test_get_annotation_for_latest_revision_status_codes(
     monkeypatch.setattr(
         "app.annotations.main.connect_s3",
         Mock(return_value=minio_accumulate_revisions),
-    )
-    monkeypatch.setattr(
-        "app.annotations.main.get_file_manifest",
-        Mock(
-            return_value={"categories": ["test_category_1", "test_category_2"]}
-        ),
     )
     params = {"page_numbers": page_numbers}
 

--- a/annotation/tests/test_get_accumulated_revisions.py
+++ b/annotation/tests/test_get_accumulated_revisions.py
@@ -124,6 +124,7 @@ EMPTY_RESPONSE = dict(
     validated=[],
     failed_validation_pages=[],
     categories=None,
+    similar_revisions=None,
 )
 LATEST_WITH_ALL_PAGES = dict(
     revision=DOCS[2].revision,
@@ -147,6 +148,7 @@ LATEST_WITH_ALL_PAGES = dict(
     validated=[3, 4, 5],
     failed_validation_pages=[1],
     categories=["test_category_1", "test_category_2"],
+    similar_revisions=None,
 )
 
 
@@ -190,6 +192,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 validated=[5],
                 failed_validation_pages=[1],
                 categories=["test_category_1", "test_category_2"],
+                similar_revisions=None,
             ),
         ),
         # find first revision and accumulate
@@ -218,6 +221,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 validated=[3],
                 failed_validation_pages=[4],
                 categories=["test_category_1", "test_category_2"],
+                similar_revisions=None,
             ),
         ),
         # find first revision and accumulate
@@ -245,6 +249,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 validated=[3],
                 failed_validation_pages=[],
                 categories=["test_category_1", "test_category_2"],
+                similar_revisions=None,
             ),
         ),
         # find second revision and accumulate
@@ -273,6 +278,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 validated=[3, 4],
                 failed_validation_pages=[1],
                 categories=["test_category_1", "test_category_2"],
+                similar_revisions=None,
             ),
         ),
         # find second revision and accumulate
@@ -292,6 +298,7 @@ LATEST_WITH_ALL_PAGES = dict(
                 validated=[],
                 failed_validation_pages=[],
                 categories=["test_category_1", "test_category_2"],
+                similar_revisions=None,
             ),
         ),
         # TODO: rework test for 404 case

--- a/annotation/tests/test_get_annotation_for_particular_revision.py
+++ b/annotation/tests/test_get_annotation_for_particular_revision.py
@@ -84,7 +84,7 @@ PART_REV_RESPONSE = {
     "pages": PART_REV_PAGES,
     "validated": PART_REV_DOC.validated,
     "failed_validation_pages": PART_REV_DOC.failed_validation_pages,
-    "categories": None,
+    "categories": [],
     "similar_revisions": None,
 }
 
@@ -129,10 +129,6 @@ def test_get_annotation_for_particular_revision_status_codes(
     monkeypatch.setattr(
         "app.annotations.main.connect_s3",
         Mock(return_value=minio_particular_revision),
-    )
-    monkeypatch.setattr(
-        "app.annotations.main.get_file_manifest",
-        Mock(return_value={}),
     )
     response = client.get(
         construct_part_rev_path(

--- a/annotation/tests/test_get_annotation_for_particular_revision.py
+++ b/annotation/tests/test_get_annotation_for_particular_revision.py
@@ -85,6 +85,7 @@ PART_REV_RESPONSE = {
     "validated": PART_REV_DOC.validated,
     "failed_validation_pages": PART_REV_DOC.failed_validation_pages,
     "categories": None,
+    "similar_revisions": None,
 }
 
 

--- a/annotation/tests/test_get_revisions.py
+++ b/annotation/tests/test_get_revisions.py
@@ -378,7 +378,9 @@ def test_get_all_revisions_sql_connection_error(
 @pytest.mark.integration
 @patch.object(boto3, "resource")
 def test_get_all_revisions_s3_connection_error(
-    boto3, prepare_db_for_get_revisions, prepare_job_for_safe_annotations,
+    boto3,
+    prepare_db_for_get_revisions,
+    prepare_job_for_safe_annotations,
 ):
     boto3.side_effect = Mock(side_effect=BotoCoreError())
     response = client.get(
@@ -748,19 +750,14 @@ def test_get_annotation_with_similarity(
         "app.annotations.main.connect_s3",
         Mock(return_value=prepare_moto_s3_for_get_revisions),
     )
-    manifest_file_mock = {"categories": ["1"]}
-    with patch(
-        "app.annotations.main.get_file_manifest",
-        return_value=manifest_file_mock,
-    ):
-        response = client.get(
-            f"{ANNOTATION_PATH}/"
-            f"{prepare_db_for_get_revisions_similar.original_job_id}/"
-            f"{prepare_db_for_get_revisions_similar.original_file_id}/"
-            f"{prepare_db_for_get_revisions_similar.original_revision}",
-            headers=TEST_HEADERS,
-            params={"page_numbers": [1]},
-        )
+    response = client.get(
+        f"{ANNOTATION_PATH}/"
+        f"{prepare_db_for_get_revisions_similar.original_job_id}/"
+        f"{prepare_db_for_get_revisions_similar.original_file_id}/"
+        f"{prepare_db_for_get_revisions_similar.original_revision}",
+        headers=TEST_HEADERS,
+        params={"page_numbers": [1]},
+    )
     expected_link = prepare_db_for_get_revisions_similar
     assert response.status_code == 200
     similar_revision = response.json()["similar_revisions"][0]

--- a/annotation/tests/test_get_revisions_without_annotation.py
+++ b/annotation/tests/test_get_revisions_without_annotation.py
@@ -108,8 +108,8 @@ REV_WITHOUT_ANNOTATION_DOC_3 = {
     "failed_validation_pages": [],
 }
 REV_WITHOUT_ANNOTATION_RESPONSE = [
-    REV_WITHOUT_ANNOTATION_DOC_1,
-    REV_WITHOUT_ANNOTATION_DOC_2,
+    {**REV_WITHOUT_ANNOTATION_DOC_1, "similar_revisions": None},
+    {**REV_WITHOUT_ANNOTATION_DOC_2, "similar_revisions": None},
 ]
 
 
@@ -131,7 +131,7 @@ def construct_rev_without_annotation_path(job_id: int, file_id: int) -> str:
             FILE_ID_2,
             DIFF_TENANT,
             200,
-            [REV_WITHOUT_ANNOTATION_DOC_3],
+            [{**REV_WITHOUT_ANNOTATION_DOC_3, "similar_revisions": None}],
         ),  # get list of one revision
         (
             NOT_EXISTING_ID,

--- a/annotation/tests/test_get_revisions_without_annotation.py
+++ b/annotation/tests/test_get_revisions_without_annotation.py
@@ -108,8 +108,16 @@ REV_WITHOUT_ANNOTATION_DOC_3 = {
     "failed_validation_pages": [],
 }
 REV_WITHOUT_ANNOTATION_RESPONSE = [
-    {**REV_WITHOUT_ANNOTATION_DOC_1, "similar_revisions": None},
-    {**REV_WITHOUT_ANNOTATION_DOC_2, "similar_revisions": None},
+    {
+        **REV_WITHOUT_ANNOTATION_DOC_1,
+        "similar_revisions": None,
+        "categories": [],
+    },
+    {
+        **REV_WITHOUT_ANNOTATION_DOC_2,
+        "similar_revisions": None,
+        "categories": [],
+    },
 ]
 
 
@@ -131,7 +139,13 @@ def construct_rev_without_annotation_path(job_id: int, file_id: int) -> str:
             FILE_ID_2,
             DIFF_TENANT,
             200,
-            [{**REV_WITHOUT_ANNOTATION_DOC_3, "similar_revisions": None}],
+            [
+                {
+                    **REV_WITHOUT_ANNOTATION_DOC_3,
+                    "similar_revisions": None,
+                    "categories": [],
+                }
+            ],
         ),  # get list of one revision
         (
             NOT_EXISTING_ID,

--- a/annotation/tests/test_post_annotation.py
+++ b/annotation/tests/test_post_annotation.py
@@ -536,6 +536,7 @@ ANNOTATED_DOC_FIRST = {
     "tenant": POST_ANNOTATION_PG_DOC.tenant,
     "task_id": POST_ANNOTATION_PG_TASK_1.id,
     "similar_revisions": None,
+    "categories": [],
 }
 ANNOTATED_DOC_PIPELINE_FIRST = {
     "revision": sha1(
@@ -558,6 +559,7 @@ ANNOTATED_DOC_PIPELINE_FIRST = {
     },
     "tenant": POST_ANNOTATION_PG_DOC.tenant,
     "similar_revisions": None,
+    "categories": [],
 }
 
 ANNOTATED_DOC_WITH_DIFFERENT_JOB_AND_FILE = copy.deepcopy(ANNOTATED_DOC_FIRST)
@@ -608,6 +610,7 @@ ANNOTATED_DOC_WITH_MANY_PAGES = {
     "tenant": POST_ANNOTATION_PG_DOC.tenant,
     "task_id": POST_ANNOTATION_PG_DOC.task_id,
     "similar_revisions": None,
+    "categories": [],
 }
 
 ANNOTATED_DOC_WITH_BASE_REVISION = {
@@ -1594,7 +1597,6 @@ def test_create_manifest_json_first_upload(
 
     expected_manifest["bucket"] = bucket_of_phys_file
     expected_manifest["file"] = s3_path_to_physical_file
-    expected_manifest["categories"] = ["science", "manifest"]
     create_manifest_json(
         annotated_doc,
         S3_PATH,
@@ -1603,7 +1605,6 @@ def test_create_manifest_json_first_upload(
         POST_ANNOTATION_PG_DOC.tenant,
         POST_ANNOTATION_JOB_1.job_id,
         POST_ANNOTATION_FILE_1.file_id,
-        ["science", "manifest"],
         prepare_db_for_manifest_creation_with_one_record,
         s3_resource,
     )
@@ -1782,7 +1783,6 @@ def test_create_manifest_json_with_annotated_docs_and_manifest_in_minio(
 
     expected_manifest["bucket"] = bucket_of_phys_file
     expected_manifest["file"] = s3_path_to_physical_file
-    expected_manifest["categories"] = ["science", "manifest"]
 
     create_manifest_json(
         annotated_doc,
@@ -1792,7 +1792,6 @@ def test_create_manifest_json_with_annotated_docs_and_manifest_in_minio(
         POST_ANNOTATION_PG_DOC.tenant,
         POST_ANNOTATION_JOB_1.job_id,
         POST_ANNOTATION_FILE_1.file_id,
-        ["science", "manifest"],
         prepare_db_for_manifest_creation_with_several_records,
         s3_resource,
     )
@@ -1972,8 +1971,16 @@ def test_construct_annotated_doc_different_jobs_and_files(
     """
     s3_resource = mock_minio_empty_bucket
 
-    expected_result_1 = ANNOTATED_DOC_FIRST
-    expected_result_2 = ANNOTATED_DOC_WITH_DIFFERENT_JOB_AND_FILE
+    expected_result_1 = {
+        k: v
+        for k, v in ANNOTATED_DOC_FIRST.items()
+        if k not in ("similar_revisions", "categories")
+    }
+    expected_result_2 = {
+        k: v
+        for k, v in ANNOTATED_DOC_WITH_DIFFERENT_JOB_AND_FILE.items()
+        if k not in ("similar_revisions", "categories")
+    }
 
     expected_path_1 = (
         f"annotation/{expected_result_1['job_id']}"
@@ -2056,27 +2063,11 @@ def test_construct_annotated_doc_different_jobs_and_files(
     assert obj_1.key == expected_path_1
     assert obj_2.key == expected_path_2
 
-    assert doc_1_in_db == {
-        k: v
-        for k, v in expected_result_1.items()
-        if k not in ("similar_revisions",)
-    }
-    assert doc_2_in_db == {
-        k: v
-        for k, v in expected_result_2.items()
-        if k not in ("similar_revisions",)
-    }
+    assert doc_1_in_db == expected_result_1
+    assert doc_2_in_db == expected_result_2
 
-    assert formatted_actual_doc_1 == {
-        k: v
-        for k, v in expected_result_1.items()
-        if k not in ("similar_revisions",)
-    }
-    assert formatted_actual_doc_2 == {
-        k: v
-        for k, v in expected_result_2.items()
-        if k not in ("similar_revisions",)
-    }
+    assert formatted_actual_doc_1 == expected_result_1
+    assert formatted_actual_doc_2 == expected_result_2
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Closes #14 
- [x] Documents support pair classification for:
  - [x] Saving
  - [x] Retrieving
- [x] Covered by tests
- [x] Alembic migrations