### PR TITLE
fix: replace the source of getting the names of annotators

### DIFF
--- a/web/src/components/task/task-sidebar-flow/index.tsx
+++ b/web/src/components/task/task-sidebar-flow/index.tsx
@@ -1,23 +1,24 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
-import { FlexRow, Panel, TabButton } from '@epam/loveship';
-import styles from './styles.module.scss';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 import { AnnotationList } from './annotation-list';
 import { Annotation } from 'shared';
 import { getSortedAllAnnotationList, getSortedAnnotationsByUserId, getTabs } from './utils';
 import { OWNER_TAB } from './constants';
 
+import { FlexRow, Panel, TabButton } from '@epam/loveship';
+import styles from './styles.module.scss';
+
 export const FlowSideBar: FC = () => {
     const [currentTab, setCurrentTab] = useState(OWNER_TAB.id);
 
     const {
-        taskUsers,
         annotationsByUserId,
         setSelectedAnnotation,
         setCurrentDocumentUserId,
         currentDocumentUserId = OWNER_TAB.id,
         allAnnotations: allAnnotationsByPageNum = {},
-        selectedAnnotation: { id: selectedAnnotationId } = {}
+        selectedAnnotation: { id: selectedAnnotationId } = {},
+        job
     } = useTaskAnnotatorContext();
 
     useEffect(() => {
@@ -30,8 +31,8 @@ export const FlowSideBar: FC = () => {
     };
 
     const tabs = useMemo(
-        () => getTabs(taskUsers.current.annotators, Object.keys(annotationsByUserId)),
-        [taskUsers.current.annotators, annotationsByUserId]
+        () => getTabs(job?.annotators ?? [], Object.keys(annotationsByUserId)),
+        [job, annotationsByUserId]
     );
 
     const allSortedAnnotations = useMemo(

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -89,7 +89,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
         documentLinks,
         onLinkChanged,
         selectedRelatedDoc,
-        taskUsers
+        job
     } = useTaskAnnotatorContext();
 
     const containerRef = useRef<HTMLDivElement>(null);
@@ -101,9 +101,10 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
     const selectedLabelsId = selectedLabels?.map(({ id }) => id) || [];
 
     const getAnnotatorName = useCallback(
-        (annotatorId: string): string =>
-            taskUsers.current.annotators.find(({ id }) => id === annotatorId)?.username || '',
-        [taskUsers]
+        (annotatorId: string): string => {
+            return job?.annotators.find(({ id }) => id === annotatorId)?.username || '';
+        },
+        [job]
     );
 
     useEffect(() => {


### PR DESCRIPTION
Closes https://github.com/epam/badgerdoc/issues/456
Replaced the source of getting the names of annotators (from `users/users/search` to `jobs/jobs/{jobId}`) 