### PR TITLE
fix: fix validation on 'create_job' to allow import label studio doc with no annotations

### DIFF
--- a/annotation/annotation/schemas/jobs.py
+++ b/annotation/annotation/schemas/jobs.py
@@ -63,7 +63,7 @@ class JobInfoSchema(BaseModel):
     files: Set[int] = Field(..., example={1, 2, 3})
     datasets: Set[int] = Field(..., example={1, 2, 3})
     is_auto_distribution: bool = Field(default=False, example=False)
-    categories: Set[str] = Field(..., example={"1", "2"})
+    categories: Optional[Set[str]] = Field(None, example={"1", "2"})
     deadline: Optional[datetime] = Field(None, example="2021-10-19 01:01:01")
     job_type: JobTypeEnumSchema = Field(
         ..., example=JobTypeEnumSchema.ExtractionJob
@@ -151,20 +151,6 @@ class JobInfoSchema(BaseModel):
                 "If the validation type is extensive_coverage number of "
                 "annotators should equal or less then provided "
                 "extensive_coverage number."
-            )
-        return values
-
-    @root_validator
-    def check_categories(cls, values):
-        """
-        If job type is ImportJob categories may not be provided.
-        In other cases there should be not less than one category provided
-        """
-        job_type = values.get("job_type")
-        categories = values.get("categories")
-        if job_type != JobTypeEnumSchema.ImportJob and not categories:
-            raise ValueError(
-                "There should be not less than one category provided"
             )
         return values
 

--- a/annotation/tests/test_job_categories.py
+++ b/annotation/tests/test_job_categories.py
@@ -221,21 +221,6 @@ def test_job_available_categories(
 
 
 @mark.integration
-def test_job_no_categories(mock_assets_communication):
-    session = mock_assets_communication
-    response = client.post(
-        f"{POST_JOBS_PATH}/{MOCK_ID}",
-        json=prepare_job_body(categories=[]),
-        headers=TEST_HEADERS,
-    )
-    error_message = "There should be not less than one category provided"
-    job = session.query(Job).get(MOCK_ID)
-    assert response.status_code == 422
-    assert error_message in response.text
-    assert not job
-
-
-@mark.integration
 @mark.parametrize(
     ["cat_ids", "request_tenant", "expected_cat_ids"],
     [

--- a/annotation/tests/test_post_job.py
+++ b/annotation/tests/test_post_job.py
@@ -435,11 +435,6 @@ def test_post_job_connection_exception(Session, prepare_db_for_post_job):
                 "at the same time."
             ),
         ),  # even in ExtractionJob must be either files or datasets
-        (
-            POST_JOB_NEW_JOBS[12],
-            422,
-            "There should be not less than one category provided",
-        ),  # even in ExtractionJob must be at least one category
     ],
 )
 @responses.activate

--- a/jobs/jobs/schemas.py
+++ b/jobs/jobs/schemas.py
@@ -161,13 +161,13 @@ class JobParams(BaseModel):
         field: ModelField,
     ) -> Union[List[int], List[str]]:
         job_type = values.get("type")
-        if v:
+        if v is not None:
             if job_type == JobType.ExtractionJob:
                 raise ValueError(
                     f"{field.name} cannot be assigned to ExtractionJob"
                 )
         elif job_type == JobType.AnnotationJob:
-            raise ValueError(f"{field.name} cannot be empty for {job_type}")
+            raise ValueError(f"{field.name} should be passed for {job_type}")
 
         return v
 

--- a/jobs/tests/test_API_functions/test_args_validation.py
+++ b/jobs/tests/test_API_functions/test_args_validation.py
@@ -33,7 +33,7 @@ def test_create_annotation_job_lack_of_data(testing_app):
             },
             {
                 "loc": ["body", "categories"],
-                "msg": "categories cannot be empty for AnnotationJob",
+                "msg": "categories should be passed for AnnotationJob",
                 "type": "value_error",
             },
         ]
@@ -469,7 +469,6 @@ def test_params_validation_for_extracting_job():
         "is_draft": False,
         "is_auto_distribution": False,
         "start_manual_job_automatically": False,
-        "categories": [],
         "owners": [
             "02336646-f5d0-4670-b111-c140a3ad58b5"
         ],


### PR DESCRIPTION
bug in issue_66 - cannot import label studio document with no annotations