### PR TITLE
perf: improve performance for rendering process of long PDF documents

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
         "@types/react-router-dom": "5.1.7",
+        "@types/react-window": "^1.8.5",
         "classnames": "^2.3.2",
         "dagre": "^0.8.5",
         "dart-sass": "1.25.0",
@@ -41,6 +42,8 @@
         "react-rnd": "^10.3.5",
         "react-router-dom": "5.2.0",
         "react-scripts": "4.0.3",
+        "react-virtualized-auto-sizer": "^1.0.20",
+        "react-window": "^1.8.9",
         "universal-cookie": "^4.0.4",
         "uuid": "^9.0.0",
         "web-vitals": "^1.0.1"

--- a/web/src/components/task/task-sidebar-flow/annotation-list.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotation-list.tsx
@@ -49,6 +49,10 @@ export const AnnotationList: FC<{
         setSelectedIndex(index);
         onSelect(selectedAnnotation);
 
+        // TODO: need to extract this logic to the place
+        // where this scrolling is really needed.
+        // For PDF-related case (when only 1 PDF doc is opened) it's not
+        // needed - in this case this scrolling will not do anything
         document
             .querySelector(`#${ANNOTATION_LABEL_ID_PREFIX}${selectedAnnotation.id}`)
             ?.scrollIntoView();

--- a/web/src/components/task/task-sidebar-flow/annotationRow.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotationRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import { ANNOTATION_FLOW_ITEM_ID_PREFIX } from 'shared/constants/annotations';
 import { ANNOTATION_PATH_SEPARATOR } from './constants';
 import { Links } from './links';
@@ -30,6 +30,13 @@ export const AnnotationRow: FC<TAnnotationProps> = ({
     onCloseIconClick
 }) => {
     const labelList = label.split('.');
+    const onIconClick = useCallback(
+        (event) => {
+            onCloseIconClick(pageNum!, id);
+            event.stopPropagation();
+        },
+        [pageNum, id, onCloseIconClick]
+    );
 
     return (
         <div
@@ -46,7 +53,7 @@ export const AnnotationRow: FC<TAnnotationProps> = ({
                     icon={closeIcon}
                     cx={styles.close}
                     iconPosition={'right'}
-                    onClick={() => onCloseIconClick(pageNum!, id)}
+                    onClick={onIconClick}
                     color={isContrastColor(color) ? 'white' : 'night900'}
                 />
                 {!links?.length && !incomingLinks?.length ? null : (

--- a/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
+++ b/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
@@ -458,6 +458,11 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
                 anntn?.labels?.splice(labelIdxToDelete, 1);
             }
         }
+
+        if (selectedAnnotation?.id === annotationId) {
+            setSelectedAnnotation(undefined);
+        }
+
         setAllAnnotations((prevState) => {
             for (let k in prevState) {
                 prevState[k].map((annList) =>

--- a/web/src/shared/components/annotator/components/table-annotation/table-annotation.tsx
+++ b/web/src/shared/components/annotator/components/table-annotation/table-annotation.tsx
@@ -321,6 +321,7 @@ export const TableAnnotation = ({
             id={getAnnotationElementId(page, id)}
         >
             <TextLabel
+                id={id}
                 color={color}
                 className={styles['tableAnnotation-label']}
                 label={label}

--- a/web/src/shared/components/annotator/components/table-annotation/table-cell-layer/table-cell-layer.tsx
+++ b/web/src/shared/components/annotator/components/table-annotation/table-cell-layer/table-cell-layer.tsx
@@ -26,6 +26,7 @@ type TableCellProps = {
 export const TableCell = ({
     label = '',
     color = 'black',
+    cell,
     bound,
     tableBound,
     isSelected,
@@ -65,6 +66,7 @@ export const TableCell = ({
             ref={annotationRef}
         >
             <TextLabel
+                id={cell.id}
                 color={color}
                 className={styles['tableAnnotation-label']}
                 label={label}

--- a/web/src/shared/components/annotator/components/text-annotation/helpers.ts
+++ b/web/src/shared/components/annotator/components/text-annotation/helpers.ts
@@ -32,17 +32,6 @@ export type TextAnnotationProps = {
 
 type LabelPosition = 'start' | 'end' | 'middle' | 'both' | 'no_label';
 
-export type TextAnnotationLabelProps = {
-    color: string;
-    labelPosition: LabelPosition;
-    label?: string;
-    onCloseIconClick?: React.MouseEventHandler<HTMLDivElement>;
-    onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
-    isEditable?: boolean;
-    isSelected?: boolean;
-    isHovered?: boolean;
-};
-
 type TextAnnBoundParams = {
     /**
      * Where is the label positioned - on the left, on the right, in the middle, both sides or nowhere

--- a/web/src/shared/components/annotator/components/text-annotation/text-annotation.tsx
+++ b/web/src/shared/components/annotator/components/text-annotation/text-annotation.tsx
@@ -2,38 +2,10 @@ import React, { Fragment, useMemo } from 'react';
 import noop from 'lodash/noop';
 
 import { stringToRGBA } from '../../utils/string-to-rgba';
-import {
-    createBoundsFromTokens,
-    getBorders,
-    TextAnnotationLabelProps,
-    TextAnnotationProps
-} from './helpers';
+import { createBoundsFromTokens, getBorders, TextAnnotationProps } from './helpers';
 import { getAnnotationElementId } from '../../utils/use-annotation-links';
 import { TextLabel } from '../text-label';
 import styles from './text-annotation.module.scss';
-
-const TextAnnotationLabel = ({
-    color,
-    label,
-    onCloseIconClick = noop,
-    onContextMenu = noop,
-    isEditable,
-    isSelected,
-    isHovered
-}: TextAnnotationLabelProps) => {
-    return (
-        <TextLabel
-            className={styles[`text-annotation-label-end`]}
-            isEditable={isEditable}
-            isSelected={isSelected}
-            isHovered={isHovered}
-            onCloseIconClick={onCloseIconClick}
-            onContextMenu={onContextMenu}
-            label={label}
-            color={color}
-        />
-    );
-};
 
 export const TextAnnotation = ({
     label = '',
@@ -99,10 +71,12 @@ export const TextAnnotation = ({
                             {singleBound.params.labelPosition != 'no_label' &&
                                 labels.map((annLabel) => (
                                     <Fragment key={annLabel.annotationId}>
-                                        <TextAnnotationLabel
-                                            color={annLabel.color ?? color}
-                                            labelPosition="end"
-                                            label={annLabel.label}
+                                        <TextLabel
+                                            id={id}
+                                            className={styles[`text-annotation-label-end`]}
+                                            isEditable={isEditable}
+                                            isSelected={isSelected}
+                                            isHovered={isHovered}
                                             onCloseIconClick={() => {
                                                 onAnnotationDelete(annLabel.annotationId!);
                                             }}
@@ -115,9 +89,8 @@ export const TextAnnotation = ({
                                                     labels
                                                 );
                                             }}
-                                            isEditable={isEditable}
-                                            isSelected={isSelected}
-                                            isHovered={isHovered}
+                                            label={annLabel.label}
+                                            color={annLabel.color ?? color}
                                         />
                                     </Fragment>
                                 ))}

--- a/web/src/shared/components/annotator/components/text-label/text-label.tsx
+++ b/web/src/shared/components/annotator/components/text-label/text-label.tsx
@@ -5,8 +5,10 @@ import { IconButton } from '@epam/loveship';
 import styles from './text-label.module.scss';
 import { cx } from '@epam/uui';
 import { getAnnotationLabelColors, isContrastColor } from 'shared/helpers/annotations';
+import { ANNOTATION_LABEL_ID_PREFIX } from 'shared/constants/annotations';
 
 type TextLabelProps = {
+    id: string | number;
     color: string;
     className: string;
     label?: string;
@@ -18,6 +20,7 @@ type TextLabelProps = {
 };
 
 export const TextLabel = ({
+    id,
     color,
     className,
     label,
@@ -28,6 +31,7 @@ export const TextLabel = ({
     isHovered
 }: TextLabelProps) => (
     <span
+        id={`${ANNOTATION_LABEL_ID_PREFIX}${id}`}
         onContextMenu={onContextMenu}
         style={getAnnotationLabelColors(color)}
         className={cx(className, { [styles.show]: isSelected || isHovered })}

--- a/web/src/shared/components/document-pages/components/document-pdf/index.tsx
+++ b/web/src/shared/components/document-pages/components/document-pdf/index.tsx
@@ -1,0 +1,83 @@
+import React, { Fragment } from 'react';
+import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
+import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';
+import { Document } from 'react-pdf';
+import { getAuthHeaders } from 'shared/helpers/auth-tools';
+import { getPdfDocumentAddress } from 'shared/helpers/get-pdf-document-address';
+import DocumentSinglePage from '../../document-single-page';
+import { Spinner } from '@epam/loveship';
+import styles from '../../document-pages.module.scss';
+import { PageSize } from '../../document-pages';
+import { PageLoadedCallback } from '../../types';
+
+type DocumentPDFProps = {
+    pageNumbers: number[];
+    handlePageLoaded: PageLoadedCallback;
+    fileMetaInfo: FileMetaInfo;
+    apiPageSize?: PageSize;
+    goToPage?: number;
+    editable: boolean;
+    fullScale: number;
+    containerRef: {
+        current: HTMLDivElement | null;
+    };
+};
+
+const DocumentPDF: React.FC<DocumentPDFProps> = ({
+    fileMetaInfo,
+    pageNumbers,
+    fullScale,
+    apiPageSize,
+    handlePageLoaded,
+    containerRef,
+    editable,
+    goToPage
+}) => {
+    const {
+        onEmptyAreaClick,
+        onAnnotationCopyPress,
+        onAnnotationCutPress,
+        onAnnotationPastePress,
+        onAnnotationUndoPress,
+        onAnnotationRedoPress
+    } = useTaskAnnotatorContext();
+
+    return (
+        <>
+            <Document
+                file={getPdfDocumentAddress(fileMetaInfo.id)}
+                loading={
+                    <div className="flex-cell">
+                        <Spinner color="sky" />
+                    </div>
+                }
+                options={{ httpHeaders: getAuthHeaders() }}
+                className={styles['document-wrapper']}
+            >
+                {pageNumbers.map((pageNum) => {
+                    return (
+                        <Fragment key={pageNum}>
+                            <DocumentSinglePage
+                                scale={fullScale}
+                                pageSize={apiPageSize}
+                                pageNum={pageNum}
+                                handlePageLoaded={handlePageLoaded}
+                                containerRef={containerRef}
+                                editable={editable}
+                                onAnnotationCopyPress={onAnnotationCopyPress}
+                                onAnnotationCutPress={onAnnotationCutPress}
+                                onAnnotationPastePress={onAnnotationPastePress}
+                                onAnnotationUndoPress={onAnnotationUndoPress}
+                                onAnnotationRedoPress={onAnnotationRedoPress}
+                                onEmptyAreaClick={onEmptyAreaClick}
+                                isScrolledToCurrent={pageNum === goToPage}
+                            />
+                        </Fragment>
+                    );
+                })}
+            </Document>
+        </>
+    );
+};
+
+export default DocumentPDF;

--- a/web/src/shared/components/document-pages/document-pages.module.scss
+++ b/web/src/shared/components/document-pages/document-pages.module.scss
@@ -14,12 +14,8 @@
     overflow: hidden;
 }
 
-.pdf-parent {
+.images-container {
     overflow: auto;
-}
-
-.document-wrapper {
-    position: relative;
 }
 
 .split-document-wrapper {

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -24,6 +24,8 @@ import ResizableSyncedContainer from './components/ResizableSyncedContainer';
 import { cx } from '@epam/uui';
 import { ValidationType } from 'api/typings';
 import { GridVariants } from 'shared/constants/task';
+import DocumentPDF from './components/document-pdf';
+import { PageLoadedCallback } from './types';
 
 export interface PageSize {
     width: number;
@@ -117,7 +119,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
         };
     }, [containerResizeObserver]);
 
-    const handlePageLoaded = (page: PDFPageProxy | HTMLImageElement) => {
+    const handlePageLoaded: PageLoadedCallback = (page) => {
         if (!originalPageSize) {
             if ('originalWidth' in page) {
                 setOriginalPageSize({ width: page.originalWidth, height: page.originalHeight });
@@ -279,40 +281,16 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                 ) : (
                     <div className={`${styles['pdf-parent']} pdf-parent`}>
                         {fileMetaInfo.extension === '.pdf' ? (
-                            <>
-                                <Document
-                                    file={getPdfDocumentAddress(fileMetaInfo.id)}
-                                    loading={
-                                        <div className="flex-cell">
-                                            <Spinner color="sky" />
-                                        </div>
-                                    }
-                                    options={{ httpHeaders: getAuthHeaders() }}
-                                    className={styles['document-wrapper']}
-                                >
-                                    {pageNumbers.map((pageNum) => {
-                                        return (
-                                            <Fragment key={pageNum}>
-                                                <DocumentSinglePage
-                                                    scale={fullScale}
-                                                    pageSize={apiPageSize}
-                                                    pageNum={pageNum}
-                                                    handlePageLoaded={handlePageLoaded}
-                                                    containerRef={containerRef}
-                                                    editable={editable}
-                                                    onAnnotationCopyPress={onAnnotationCopyPress}
-                                                    onAnnotationCutPress={onAnnotationCutPress}
-                                                    onAnnotationPastePress={onAnnotationPastePress}
-                                                    onAnnotationUndoPress={onAnnotationUndoPress}
-                                                    onAnnotationRedoPress={onAnnotationRedoPress}
-                                                    onEmptyAreaClick={onEmptyAreaClick}
-                                                    isScrolledToCurrent={pageNum === goToPage}
-                                                />
-                                            </Fragment>
-                                        );
-                                    })}
-                                </Document>
-                            </>
+                            <DocumentPDF
+                                fileMetaInfo={fileMetaInfo}
+                                pageNumbers={pageNumbers}
+                                fullScale={fullScale}
+                                apiPageSize={apiPageSize}
+                                handlePageLoaded={handlePageLoaded}
+                                containerRef={containerRef}
+                                editable={editable}
+                                goToPage={goToPage}
+                            />
                         ) : null}
                         {fileMetaInfo.extension === '.jpg' ? (
                             <>

--- a/web/src/shared/components/document-pages/types.ts
+++ b/web/src/shared/components/document-pages/types.ts
@@ -1,0 +1,3 @@
+import { PDFPageProxy } from 'react-pdf';
+
+export type PageLoadedCallback = (page: PDFPageProxy | HTMLImageElement) => void;

--- a/web/src/shared/components/document-pages/types.ts
+++ b/web/src/shared/components/document-pages/types.ts
@@ -1,3 +1,34 @@
-import { PDFPageProxy } from 'react-pdf';
+import { ReactNode } from 'react';
+import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';
+import { PDFPageProxy, DocumentProps } from 'react-pdf';
+import { Annotation } from 'shared';
+import { GridVariants } from 'shared/constants/task';
+
+type RenderLinksParams = {
+    updLinks: boolean;
+    scale: number;
+    annotations?: Record<number, Annotation[]>;
+};
+
+export interface PageSize {
+    width: number;
+    height: number;
+}
+
+export type DocumentPagesProps = {
+    renderLinks?: (params: RenderLinksParams) => ReactNode;
+    pageNumbers?: number[];
+    fileMetaInfo: FileMetaInfo;
+    apiPageSize?: PageSize;
+    additionalScale: number;
+    goToPage?: number;
+    setPageSize?: (nS: any) => void;
+    editable: boolean;
+    gridVariant: GridVariants;
+};
 
 export type PageLoadedCallback = (page: PDFPageProxy | HTMLImageElement) => void;
+
+// there is no PDFDocumentProxy exported by react-pdf, extracting it manually from
+// DocumentProps
+export type DocumentLoadedCallback = Required<DocumentProps>['onLoadSuccess'];

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2603,6 +2603,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-window@^1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
+  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^17.0.0":
   version "17.0.21"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.21.tgz"
@@ -9007,6 +9014,11 @@ media-typer@0.3.0:
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz"
@@ -11533,6 +11545,11 @@ react-transition-group@4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-virtualized-auto-sizer@^1.0.20:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz#d9a907253a7c221c52fa57dc775a6ef40c182645"
+  integrity sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==
+
 react-virtualized@^9.22.3:
   version "9.22.3"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
@@ -11544,6 +11561,14 @@ react-virtualized@^9.22.3:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
+
+react-window@^1.8.9:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.9.tgz#24bc346be73d0468cdf91998aac94e32bc7fa6a8"
+  integrity sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
**Actual result**: when PDF doc with 1000 pages is opened, the browser's tab with the app is crashed.
**Expected result**: PDF doc with 1000 pages is opened without crashing. 

In the scope of this PR, performance for rendering process of PDF docs was improved.
PR is not tested on potential example with a lot of annotations, only with big PDF file (about 1000 pages and couple of shown annotations).
The main approach is to use `react-window` library to render only part of PDF file, during scrolling this part will be updated. This will allow us to not keep a lot of DOM elements at the same time (otherwise the browser may not have enough RAM for such big count of elements).
Also, `Page`'s `renderTextLayer` is set to `false` to not render selectable text above PDF - as we discussed with @khyurri it's not needed (now it actually can't be selected manually, only way to do this is to press CMD+A/CTRL+A to select all text on the page including this autogenerated text but it looks like it doesn't make sence).

There is one open topic about annotation selection:
Now in case if some annotation is selected via one click (via PDF doc itself or via annotation LHP), the doc is immediately selected & scrolled to the place. Before when this selection via one click happened it's NOT scrolled immediately BUT only selected (but happened on the second one). I'm not sure which UX approach is better here, keeping my for now but it may not be the best one.
