### PR TITLE
perf: load annotations for PDF in chunks

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^17.0.0",
         "@types/react-router-dom": "5.1.7",
         "@types/react-window": "^1.8.5",
+        "@types/react-window-infinite-loader": "^1.0.6",
         "classnames": "^2.3.2",
         "dagre": "^0.8.5",
         "dart-sass": "1.25.0",
@@ -44,7 +45,9 @@
         "react-scripts": "4.0.3",
         "react-virtualized-auto-sizer": "^1.0.20",
         "react-window": "^1.8.9",
+        "react-window-infinite-loader": "^1.0.9",
         "universal-cookie": "^4.0.4",
+        "use-debounce": "^9.0.4",
         "uuid": "^9.0.0",
         "web-vitals": "^1.0.1"
     },

--- a/web/src/api/hooks/annotations.ts
+++ b/web/src/api/hooks/annotations.ts
@@ -1,6 +1,6 @@
 import { CategoryDataAttrType, MutationHookType, PageInfo, QueryHookType } from 'api/typings';
 import { Task } from 'api/typings/tasks';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useBadgerFetch } from './api';
 import { JobStatus } from '../typings/jobs';
 import { LatestRevisionResponse } from '../../connectors/task-annotator-connector/revisionTypes';
@@ -77,6 +77,16 @@ export const useLatestAnnotations: QueryHookType<LatestAnnotationsParams, Annota
         async () => fetchLatestAnnotations(jobId, fileId, revisionId, pageNumbers, userId),
         options
     );
+};
+
+export const useLatestAnnotationsFetcher = () => {
+    const queryClient = useQueryClient();
+
+    return ({ jobId, fileId, revisionId, pageNumbers, userId }: LatestAnnotationsParams) =>
+        queryClient.fetchQuery(
+            ['latestAnnotations', jobId, fileId, revisionId, pageNumbers, userId],
+            async () => fetchLatestAnnotations(jobId, fileId, revisionId, pageNumbers, userId)
+        );
 };
 
 export const useLatestAnnotationsByUser: QueryHookType<

--- a/web/src/api/hooks/annotations.ts
+++ b/web/src/api/hooks/annotations.ts
@@ -97,10 +97,11 @@ async function fetchLatestAnnotations(
     pageNumbers?: number[],
     userId?: string
 ): Promise<AnnotationsResponse> {
+    const pageNums = pageNumbers?.map((pageNumber) => `page_numbers=${pageNumber}`);
     const revId = revisionId || 'latest';
     const user = userId ? `&user_id=${userId}` : '';
     return useBadgerFetch<AnnotationsResponse>({
-        url: `${namespace}/annotation/${jobId}/${fileId}/${revId}?${user}`,
+        url: `${namespace}/annotation/${jobId}/${fileId}/${revId}?${pageNums?.join('&')}${user}`,
         method: 'get',
         withCredentials: true
     })();

--- a/web/src/components/task/task-sidebar-flow/__tests__/annotation-list.test.tsx
+++ b/web/src/components/task/task-sidebar-flow/__tests__/annotation-list.test.tsx
@@ -26,16 +26,11 @@ describe('AnnotationList', () => {
     const secondAnnotation = createAnnotation('second', 'categoryName', 'categoryName', '#FFFFF');
     const props = {
         list: [firstAnnotation, secondAnnotation],
-        selectedAnnotationId: 'first',
+        selectedAnnotation: firstAnnotation,
         onSelect: () => {},
-        isEditable: false,
-        onLinkDeleted: () => {},
-        onLabelSelect: () => {},
-        onLabelDelete: () => {},
-        onAnnotationDeleted: () => {},
-        isOwner: false,
-        labels: []
+        isEditable: false
     };
+
     it('Must select another annotation if selectedAnnotationId is changed', () => {
         const firstAnnotationRowId = `${ANNOTATION_FLOW_ITEM_ID_PREFIX}${firstAnnotation.id}`;
         const secondAnnotationRowId = `${ANNOTATION_FLOW_ITEM_ID_PREFIX}${secondAnnotation.id}`;
@@ -52,7 +47,7 @@ describe('AnnotationList', () => {
             backgroundColor: 'unset'
         });
 
-        rerender(<AnnotationList {...props} selectedAnnotationId="second" />);
+        rerender(<AnnotationList {...props} selectedAnnotation={secondAnnotation} />);
 
         expect(getByTestId('flow-prev-button').getAttribute('aria-disabled')).toBe('false');
         expect(getByTestId('flow-next-button').getAttribute('aria-disabled')).toBe('true');

--- a/web/src/components/task/task-sidebar-flow/annotation-list.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotation-list.tsx
@@ -1,67 +1,130 @@
-import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnnotationRow } from './annotationRow';
-import { Annotation } from 'shared';
+import { Annotation, Maybe } from 'shared';
 import {
     ANNOTATION_FLOW_ITEM_ID_PREFIX,
     ANNOTATION_LABEL_ID_PREFIX
 } from 'shared/constants/annotations';
+import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 
 import { ReactComponent as goLastIcon } from '@epam/assets/icons/common/navigation-chevron-down_down-18.svg';
 import { ReactComponent as goNextIcon } from '@epam/assets/icons/common/navigation-chevron-down-18.svg';
 import { ReactComponent as goPrevIcon } from '@epam/assets/icons/common/navigation-chevron-up-18.svg';
 import { ReactComponent as goFirstIcon } from '@epam/assets/icons/common/navigation-chevron-up_up-18.svg';
 import { collectIncomingLinks } from './utils';
-import { Link } from 'api/typings';
 
-import { Button, FlexRow, Text } from '@epam/loveship';
+import { Button, FlexRow, Text, TextPlaceholder } from '@epam/loveship';
 import styles from './task-sidebar-flow.module.scss';
+import { NoData } from 'shared/no-data';
+import { scrollIntoViewIfNeeded } from 'shared/helpers/scroll-into-view-if-needed';
 
-export const AnnotationList: FC<{
+type AnnotationListProps = {
     list: Annotation[];
     isEditable: boolean;
-    selectedAnnotationId?: Annotation['id'];
-    onLinkDeleted: (pageNum: number, annotationId: Annotation['id'], link: Link) => void;
-    onAnnotationDeleted: (pageNum: number, annotationId: Annotation['id']) => void;
+    selectedAnnotation: Maybe<Annotation>;
     onSelect: (annotation: Annotation) => void;
-}> = ({ list, isEditable, selectedAnnotationId, onSelect, onLinkDeleted, onAnnotationDeleted }) => {
+};
+
+const AnnotationCounter: FC<{ selectedAnnotation: Annotation }> = ({ selectedAnnotation }) => {
+    const { allAnnotations, pageNumbers } = useTaskAnnotatorContext();
+    const annotationsForPage = allAnnotations![selectedAnnotation.pageNum!];
+    const selectedAnnotationIndexPerPage = annotationsForPage.findIndex(
+        ({ id }) => selectedAnnotation.id === id
+    );
+    const uiPageNumber = pageNumbers.findIndex(
+        (pageNumber) => pageNumber === selectedAnnotation.pageNum
+    );
+
+    return (
+        <Text color="night500" cx={styles.counter}>
+            Page {uiPageNumber + 1} : {selectedAnnotationIndexPerPage + 1} of{' '}
+            {annotationsForPage.length}
+        </Text>
+    );
+};
+
+const AnnotationListPlaceholder: FC<{ countOfItems: number }> = ({ countOfItems }) => {
+    const items = useMemo(() => Array.from({ length: countOfItems }), [countOfItems]);
+
+    return (
+        <div className={styles['annotation-list-container']}>
+            {items.map((_, index) => (
+                <div key={index} className={styles.item}>
+                    <div className={styles['placeholder-header']}>
+                        <TextPlaceholder cx={styles['placeholder-header__item']}></TextPlaceholder>
+                    </div>
+                    <div className={styles['placeholder-content']}>
+                        <TextPlaceholder
+                            cx={styles['placeholder-content__item']}
+                            wordsCount={9}
+                        ></TextPlaceholder>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export const AnnotationList: FC<AnnotationListProps> = ({
+    list,
+    isEditable,
+    selectedAnnotation,
+    onSelect
+}) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const [selectedIndex, setSelectedIndex] = useState<number>(0);
     const [isSelectedInCurrentView, setIsSelectedInCurrentView] = useState<boolean>(false);
+    const { areLatestAnnotationsFetching, onLinkDeleted, onAnnotationDeleted, allAnnotations } =
+        useTaskAnnotatorContext();
+    const { incomingLinksByAnnotationId, annotationNameById } = useMemo(
+        () => collectIncomingLinks(list),
+        [list]
+    );
 
     useEffect(() => {
-        if (!selectedAnnotationId) {
+        if (!selectedAnnotation) {
             setIsSelectedInCurrentView(false);
             return;
         }
 
-        const index = list.findIndex(({ id }) => id === selectedAnnotationId);
+        const index = list.findIndex(({ id }) => id === selectedAnnotation.id);
 
         setSelectedIndex(index);
         setIsSelectedInCurrentView(index !== -1);
 
-        containerRef.current
-            ?.querySelector(`#${ANNOTATION_FLOW_ITEM_ID_PREFIX}${selectedAnnotationId}`)
-            ?.scrollIntoView();
-    }, [list, selectedAnnotationId]);
+        const annotationItemElement = containerRef.current?.querySelector(
+            `#${ANNOTATION_FLOW_ITEM_ID_PREFIX}${selectedAnnotation.id}`
+        );
 
-    const handleSelect = (index: number) => {
-        const selectedAnnotation = list[index];
-        setSelectedIndex(index);
-        onSelect(selectedAnnotation);
+        if (containerRef.current && annotationItemElement) {
+            scrollIntoViewIfNeeded(containerRef.current, annotationItemElement);
+        }
+    }, [list, selectedAnnotation]);
 
-        // TODO: need to extract this logic to the place
-        // where this scrolling is really needed.
-        // For PDF-related case (when only 1 PDF doc is opened) it's not
-        // needed - in this case this scrolling will not do anything
-        document
-            .querySelector(`#${ANNOTATION_LABEL_ID_PREFIX}${selectedAnnotation.id}`)
-            ?.scrollIntoView();
-    };
+    const handleSelect = useCallback(
+        (index: number) => {
+            const newSelectedAnnotation = list[index];
+            setSelectedIndex(index);
+            onSelect(newSelectedAnnotation);
 
-    const handleSelectById = (id: Annotation['id']) => {
-        const index = list.findIndex((item) => item.id === id);
-        handleSelect(index);
-    };
+            // TODO: need to extract this logic to the place
+            // where this scrolling is really needed.
+            // For PDF-related case (when only 1 PDF doc is opened) it's not
+            // needed - in this case this scrolling will not do anything
+            document
+                .querySelector(`#${ANNOTATION_LABEL_ID_PREFIX}${newSelectedAnnotation.id}`)
+                ?.scrollIntoView();
+        },
+        [list, onSelect]
+    );
+
+    const handleSelectById = useCallback(
+        (id: Annotation['id']) => {
+            const index = list.findIndex((item) => item.id === id);
+            handleSelect(index);
+        },
+        [handleSelect, list]
+    );
 
     const handleGoPrev = () => {
         const prevIndex = !selectedIndex ? 0 : selectedIndex - 1;
@@ -75,11 +138,6 @@ export const AnnotationList: FC<{
 
     const isOnFirstElement = !selectedIndex || !isSelectedInCurrentView;
     const isOnLastElement = !isSelectedInCurrentView || selectedIndex === list.length - 1;
-
-    const { incomingLinksByAnnotationId, annotationNameById } = useMemo(
-        () => collectIncomingLinks(list),
-        [list]
-    );
 
     return (
         <>
@@ -118,28 +176,32 @@ export const AnnotationList: FC<{
                     isDisabled={isOnFirstElement}
                     rawProps={{ 'data-testid': 'flow-prev-button' }}
                 />
-                {!isSelectedInCurrentView ? null : (
-                    <Text color="night500" cx={styles.counter}>
-                        {selectedIndex + 1} of {list.length}
-                    </Text>
+                {!!selectedAnnotation && allAnnotations![selectedAnnotation.pageNum!] && (
+                    <AnnotationCounter selectedAnnotation={selectedAnnotation}></AnnotationCounter>
                 )}
             </FlexRow>
-            <div className={styles.listContainer} ref={containerRef}>
-                {list.map((annotation, index) => (
-                    <AnnotationRow
-                        {...annotation}
-                        index={index}
-                        isEditable={isEditable}
-                        key={`${annotation.id}-${index}`}
-                        onLinkDeleted={onLinkDeleted}
-                        annotationNameById={annotationNameById}
-                        incomingLinks={incomingLinksByAnnotationId[annotation.id]}
-                        onSelect={handleSelect}
-                        onSelectById={handleSelectById}
-                        selectedAnnotationId={selectedAnnotationId}
-                        onCloseIconClick={onAnnotationDeleted}
-                    />
-                ))}
+            <div className={styles['annotation-container']} ref={containerRef}>
+                {areLatestAnnotationsFetching ? (
+                    <AnnotationListPlaceholder countOfItems={5}></AnnotationListPlaceholder>
+                ) : list.length === 0 ? (
+                    <NoData title="No annotations for the viewed pages" />
+                ) : (
+                    list.map((annotation, index) => (
+                        <AnnotationRow
+                            {...annotation}
+                            index={index}
+                            isEditable={isEditable}
+                            key={`${annotation.id}-${index}`}
+                            onLinkDeleted={onLinkDeleted}
+                            annotationNameById={annotationNameById}
+                            incomingLinks={incomingLinksByAnnotationId[annotation.id]}
+                            onSelect={handleSelect}
+                            onSelectById={handleSelectById}
+                            selectedAnnotationId={selectedAnnotation?.id}
+                            onCloseIconClick={onAnnotationDeleted}
+                        />
+                    ))
+                )}
             </div>
         </>
     );

--- a/web/src/components/task/task-sidebar-flow/task-sidebar-flow.module.scss
+++ b/web/src/components/task/task-sidebar-flow/task-sidebar-flow.module.scss
@@ -1,9 +1,8 @@
-.listContainer {
-    display: flex;
-    flex-direction: column;
-    max-height: 100%;
-    padding: 8px;
+@import '@epam/assets/scss/promo/colors.scss';
+
+.annotation-container {
     height: 100%;
+    padding: 8px;
     overflow: auto;
 }
 
@@ -56,6 +55,11 @@
 .toolbar {
     min-height: unset;
     padding: 16px 16px 4px 16px;
+
+    .counter {
+        padding: 0;
+        margin-left: 6px;
+    }
 }
 
 .button {
@@ -63,10 +67,6 @@
         width: 12px;
         height: 12px;
     }
-}
-
-.counter {
-    padding: 0;
 }
 
 .tab {
@@ -111,9 +111,9 @@
     }
 
     &::-webkit-scrollbar-thumb {
-        background-color: #{"hsl(0 0% 70%)"};
+        background-color: #{'hsl(0 0% 70%)'};
         border-radius: 15px;
-        border: 3px solid #{"hsl(0 0% 70%)"};
+        border: 3px solid #{'hsl(0 0% 70%)'};
     }
 }
 
@@ -168,4 +168,28 @@
     &:not(:last-child) {
         margin-bottom: 2px;
     }
+}
+
+.placeholder-header {
+    background-color: $green-lightest;
+    height: 28px;
+    display: flex;
+    align-items: center;
+}
+
+.placeholder-header__item {
+    margin-top: 3px;
+    margin-left: 5px;
+    height: 12px;
+    width: 90px;
+}
+
+.placeholder-content {
+    padding: 6px 0 9px;
+}
+
+.placeholder-content__item {
+    height: 12px;
+    margin-top: 5px;
+    margin-right: 5px;
 }

--- a/web/src/components/task/task-sidebar-flow/task-sidebar-flow.tsx
+++ b/web/src/components/task/task-sidebar-flow/task-sidebar-flow.tsx
@@ -5,7 +5,6 @@ import { getTabs, getSortedAllAnnotationList } from './utils';
 import { OWNER_TAB, VISIBILITY_SETTING_ID } from './constants';
 import { ReactComponent as closeIcon } from '@epam/assets/icons/common/navigation-chevron-left_left-18.svg';
 import { ReactComponent as openIcon } from '@epam/assets/icons/common/navigation-chevron-right_right-18.svg';
-
 import { Button, FlexRow, Panel, TabButton, Tooltip } from '@epam/loveship';
 import styles from './task-sidebar-flow.module.scss';
 import { useLabels } from 'shared/hooks/use-labels';
@@ -17,16 +16,14 @@ export const FlowSideBar: FC = () => {
     });
 
     const {
-        onLinkDeleted,
         isSplitValidation,
-        onAnnotationDeleted,
         setSelectedAnnotation,
         job: { annotators } = {},
         setCurrentDocumentUserId,
         latestRevisionByAnnotatorsWithBounds,
         currentDocumentUserId = OWNER_TAB.id,
         allAnnotations: allAnnotationsByPageNum = {},
-        selectedAnnotation: { id: selectedAnnotationId } = {}
+        selectedAnnotation
     } = useTaskAnnotatorContext();
 
     const { currentTab, setCurrentTab } = useLabels();
@@ -99,12 +96,10 @@ export const FlowSideBar: FC = () => {
                     )}
                     {annotationsByTab[currentTab] && (
                         <AnnotationList
-                            onLinkDeleted={onLinkDeleted}
-                            onAnnotationDeleted={onAnnotationDeleted}
                             onSelect={setSelectedAnnotation}
                             list={annotationsByTab[currentTab]}
                             isEditable={currentTab === OWNER_TAB.id}
-                            selectedAnnotationId={selectedAnnotationId}
+                            selectedAnnotation={selectedAnnotation}
                         />
                     )}
                 </Panel>

--- a/web/src/components/task/task-sidebar/task-sidebar.tsx
+++ b/web/src/components/task/task-sidebar/task-sidebar.tsx
@@ -82,6 +82,7 @@ const TaskSidebar: FC<TaskSidebarProps> = ({ jobSettings, viewMode, isNextTaskPr
         onEditClick,
         onClearTouchedPages,
         onClearModifiedPages,
+        clearAnnotationsChanges,
         onAddTouchedPage,
         onCancelClick,
         onSaveEditClick,
@@ -321,6 +322,7 @@ const TaskSidebar: FC<TaskSidebarProps> = ({ jobSettings, viewMode, isNextTaskPr
         await onSaveTask();
         onClearTouchedPages();
         onClearModifiedPages();
+        clearAnnotationsChanges();
         refetch();
     };
 

--- a/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
+++ b/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
@@ -1060,7 +1060,7 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
     );
     const { getAnnotationLabels, mapAnnotationPagesFromApi } = useAnnotationsMapper(
         comparedTaxonLabels,
-        [latestAnnotationsResultData?.pages, comparedTaxonLabels]
+        [latestAnnotationsResultData?.pages, comparedTaxonLabels, annotationsChanges]
     );
 
     useEffect(() => {

--- a/web/src/connectors/task-annotator-connector/use-document-data-full-loading/index.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-full-loading/index.ts
@@ -1,0 +1,65 @@
+import { AnnotationsResponse, useLatestAnnotations } from 'api/hooks/annotations';
+import { useTokensFullLoading } from './use-tokens-full-loading';
+import { TDocumentDataFullLoadingParams } from './types';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const functionStub = () => {};
+
+export const useDocumentDataFullLoading = (
+    { revisionId, pageNumbers, task, job, jobId, fileMetaInfo }: TDocumentDataFullLoadingParams,
+    { enabled: hookEnabled }: { enabled: boolean }
+) => {
+    const [latestAnnotationsResultData, setLatestAnnotationsResultData] =
+        useState<AnnotationsResponse>();
+    const getJobId = () => (task ? task.job.id : jobId);
+    const getFileId = () => (task ? task.file.id : fileMetaInfo?.id);
+
+    const { tokenPages, tokenRes } = useTokensFullLoading(
+        { pageNumbers, task, fileMetaInfo },
+        { enabled: hookEnabled }
+    );
+    const latestAnnotationsResult = useLatestAnnotations(
+        {
+            jobId: getJobId(),
+            fileId: getFileId(),
+            revisionId,
+            pageNumbers,
+            userId:
+                job?.validation_type === 'extensive_coverage' && !revisionId ? task?.user_id : ''
+        },
+        {
+            enabled: hookEnabled && Boolean(task || job),
+            onSuccess: (data) => setLatestAnnotationsResultData(data)
+        }
+    );
+
+    const documentDataRefetcher = useRef(() => {
+        latestAnnotationsResult.refetch();
+        tokenRes.refetch();
+    });
+
+    useEffect(() => {
+        if (!hookEnabled) {
+            return;
+        }
+
+        if (task || job || revisionId) {
+            documentDataRefetcher.current();
+        }
+    }, [task, job, revisionId, hookEnabled]);
+
+    const availableRenderedPagesRange = useMemo(
+        () => ({ begin: 0, end: pageNumbers.length - 1 }),
+        [pageNumbers]
+    );
+
+    return {
+        tokenPages,
+        latestAnnotationsResult,
+        latestAnnotationsResultData,
+        availableRenderedPagesRange,
+        setAvailableRenderedPagesRange: functionStub,
+        getNextDocumentItems: functionStub,
+        isDocumentPageDataLoaded: () => true
+    };
+};

--- a/web/src/connectors/task-annotator-connector/use-document-data-full-loading/index.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-full-loading/index.ts
@@ -1,7 +1,7 @@
 import { AnnotationsResponse, useLatestAnnotations } from 'api/hooks/annotations';
 import { useTokensFullLoading } from './use-tokens-full-loading';
 import { TDocumentDataFullLoadingParams } from './types';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const functionStub = () => {};
 
@@ -33,8 +33,12 @@ export const useDocumentDataFullLoading = (
         }
     );
 
+    const refetchLatestAnnotations = useCallback(async () => {
+        await latestAnnotationsResult.refetch();
+    }, [latestAnnotationsResult]);
+
     const documentDataRefetcher = useRef(() => {
-        latestAnnotationsResult.refetch();
+        refetchLatestAnnotations();
         tokenRes.refetch();
     });
 
@@ -58,6 +62,7 @@ export const useDocumentDataFullLoading = (
         latestAnnotationsResult,
         latestAnnotationsResultData,
         availableRenderedPagesRange,
+        refetchLatestAnnotations,
         setAvailableRenderedPagesRange: functionStub,
         getNextDocumentItems: functionStub,
         isDocumentPageDataLoaded: () => true

--- a/web/src/connectors/task-annotator-connector/use-document-data-full-loading/types.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-full-loading/types.ts
@@ -1,0 +1,17 @@
+import { Job } from 'api/typings/jobs';
+import { Task } from 'api/typings/tasks';
+import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';
+
+export type TDocumentDataFullLoadingParams = {
+    task?: Task;
+    job?: Job;
+    jobId?: number;
+    fileMetaInfo?: FileMetaInfo;
+    revisionId?: string;
+    pageNumbers: number[];
+};
+
+export type TTokensFullLoadingParams = Pick<
+    TDocumentDataFullLoadingParams,
+    'task' | 'fileMetaInfo' | 'pageNumbers'
+>;

--- a/web/src/connectors/task-annotator-connector/use-document-data-full-loading/use-tokens-full-loading.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-full-loading/use-tokens-full-loading.ts
@@ -1,0 +1,39 @@
+import { useTokens } from 'api/hooks/tokens';
+import { PageInfo } from 'api/typings';
+import { useEffect, useState } from 'react';
+import { TTokensFullLoadingParams } from './types';
+
+const PAGE_TOKENS_CHUNK_SIZE = 5;
+
+export const useTokensFullLoading = (
+    { pageNumbers, task, fileMetaInfo }: TTokensFullLoadingParams,
+    { enabled: hookEnabled }: { enabled: boolean }
+) => {
+    const [tokenPages, setTokenPages] = useState<PageInfo[]>([]);
+    const [tokenPagesChunk, setTokenPagesChunk] = useState<number>(0);
+    const getFileId = () => (task ? task.file.id : fileMetaInfo?.id);
+
+    const tokenRes = useTokens(
+        {
+            fileId: getFileId(),
+            pageNumbers: pageNumbers.slice(
+                tokenPagesChunk,
+                tokenPagesChunk + PAGE_TOKENS_CHUNK_SIZE
+            )
+        },
+        { enabled: hookEnabled && tokenPagesChunk < pageNumbers.length }
+    );
+
+    useEffect(() => {
+        if (hookEnabled && tokenRes.status === 'success') {
+            if (tokenRes.data.length > 0 && tokenPagesChunk < pageNumbers.length) {
+                setTokenPages((prevTokenPages) => [...prevTokenPages, ...tokenRes.data]);
+                setTokenPagesChunk(
+                    (prevTokenPagesChunk) => prevTokenPagesChunk + PAGE_TOKENS_CHUNK_SIZE
+                );
+            }
+        }
+    }, [hookEnabled, pageNumbers.length, tokenPagesChunk, tokenRes]);
+
+    return { tokenRes, tokenPages };
+};

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/index.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/index.ts
@@ -39,7 +39,8 @@ export const useDocumentDataLazyLoading = (
     const {
         latestAnnotationsQuery,
         latestAnnotationsResultData,
-        cachedPageIndexesRange: cachedAnnotationsPageIndexesRange
+        cachedPageIndexesRange: cachedAnnotationsPageIndexesRange,
+        refetchLatestAnnotationsIfNeeded
     } = useAnnotationsLazyLoading(
         {
             task,
@@ -104,6 +105,7 @@ export const useDocumentDataLazyLoading = (
 
     return {
         latestAnnotationsResult: latestAnnotationsQuery,
+        refetchLatestAnnotations: refetchLatestAnnotationsIfNeeded,
         latestAnnotationsResultData,
         availableRenderedPagesRange,
         tokenPages,

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/index.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/index.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAnnotationsLazyLoading } from './use-annotations-lazy-loading';
+import { useTokensLazyLoading } from './use-tokens-lazy-loading';
+import { TDocumentDataLazyLoadingParams } from './types';
+
+const createPendingPromise = () => {
+    let resolver: (value: unknown) => void;
+    const promise = new Promise((resolve) => {
+        resolver = resolve;
+    });
+
+    return { promise, resolver: resolver! };
+};
+
+export const useDocumentDataLazyLoading = (
+    {
+        task,
+        job,
+        jobId,
+        fileMetaInfo,
+        revisionId,
+        pageNumbers,
+        setSelectedAnnotation
+    }: TDocumentDataLazyLoadingParams,
+    { enabled: hookEnabled }: { enabled: boolean }
+) => {
+    const [nextLoadingPagesRange, setNextLoadingPagesRange] = useState({ begin: -1, end: -1 });
+    const [availableRenderedPagesRange, setAvailableRenderedPagesRange] = useState({
+        begin: -1,
+        end: -1
+    });
+    const [isDataLoadingPromise, setIsDataLoadingPromise] = useState(() => createPendingPromise());
+
+    const nextLoadingPageNumbers = pageNumbers.slice(
+        nextLoadingPagesRange.begin,
+        nextLoadingPagesRange.end + 1
+    );
+
+    const {
+        latestAnnotationsQuery,
+        latestAnnotationsResultData,
+        cachedPageIndexesRange: cachedAnnotationsPageIndexesRange
+    } = useAnnotationsLazyLoading(
+        {
+            task,
+            job,
+            jobId,
+            fileMetaInfo,
+            revisionId,
+            nextLoadingPageNumbers,
+            pageNumbers,
+            availableRenderedPagesRange,
+            nextLoadingPagesRange,
+            setSelectedAnnotation
+        },
+        { enabled: hookEnabled }
+    );
+
+    const getNextDocumentItems = async (startIndex: number, stopIndex: number) => {
+        const pendingState = createPendingPromise();
+        setIsDataLoadingPromise(pendingState);
+        setNextLoadingPagesRange({ begin: startIndex, end: stopIndex });
+
+        await pendingState.promise;
+    };
+
+    const {
+        tokenQuery,
+        tokenPages,
+        cachedPageIndexesRange: cachedTokensPageIndexesRange
+    } = useTokensLazyLoading(
+        {
+            task,
+            fileMetaInfo,
+            nextLoadingPageNumbers,
+            pageNumbers,
+            availableRenderedPagesRange,
+            nextLoadingPagesRange
+        },
+        { enabled: hookEnabled }
+    );
+
+    useEffect(() => {
+        if (hookEnabled && latestAnnotationsQuery.isSuccess && tokenQuery.isSuccess) {
+            isDataLoadingPromise.resolver(undefined);
+        }
+    }, [latestAnnotationsQuery.isSuccess, tokenQuery.isSuccess, isDataLoadingPromise, hookEnabled]);
+
+    // Our cached items are based on the range of loaded page indexes (based on first and last rendered page index),
+    // not on the loaded data itself. It's done in such way because BE doesn't return any data for the
+    // loading pages in case if they were not edited yet (no annotations were added yet). In such situation,
+    // we assume that the data is actually loaded for the particular page in order to not make additional request
+    // for it (without this since there are no data returned by BE, our loading mechanism will assume that it requires
+    // additional request to load it). This is mostly a workaround and ideally BE should return to FE always some
+    // data even in case if the page was not edited yet
+    const isDocumentPageDataLoaded = useCallback(
+        (index: number) =>
+            cachedAnnotationsPageIndexesRange.begin <= index &&
+            index <= cachedAnnotationsPageIndexesRange.end &&
+            cachedTokensPageIndexesRange.begin <= index &&
+            index <= cachedTokensPageIndexesRange.end,
+        [cachedAnnotationsPageIndexesRange, cachedTokensPageIndexesRange]
+    );
+
+    return {
+        latestAnnotationsResult: latestAnnotationsQuery,
+        latestAnnotationsResultData,
+        availableRenderedPagesRange,
+        tokenPages,
+        setAvailableRenderedPagesRange,
+        getNextDocumentItems,
+        isDocumentPageDataLoaded
+    };
+};

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/types.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/types.ts
@@ -1,0 +1,35 @@
+import { Job } from 'api/typings/jobs';
+import { Task } from 'api/typings/tasks';
+import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';
+import { Dispatch, SetStateAction } from 'react';
+import { Annotation } from 'shared';
+
+export type TRange = {
+    begin: number;
+    end: number;
+};
+
+export type TDocumentDataLazyLoadingParams = {
+    task?: Task;
+    job?: Job;
+    jobId?: number;
+    fileMetaInfo?: FileMetaInfo;
+    revisionId?: string;
+    pageNumbers: number[];
+    setSelectedAnnotation: Dispatch<SetStateAction<Annotation | undefined>>;
+};
+
+export type TAnnotationsLazyLoadingParams = TDocumentDataLazyLoadingParams & {
+    availableRenderedPagesRange: TRange;
+    nextLoadingPagesRange: TRange;
+    nextLoadingPageNumbers: number[];
+};
+
+export type TTokensLazyLoadingParams = Pick<
+    TDocumentDataLazyLoadingParams,
+    'task' | 'fileMetaInfo' | 'pageNumbers'
+> & {
+    availableRenderedPagesRange: TRange;
+    nextLoadingPagesRange: TRange;
+    nextLoadingPageNumbers: number[];
+};

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
@@ -1,11 +1,45 @@
 import { useState } from 'react';
-import { AnnotationsResponse, useLatestAnnotations } from 'api/hooks/annotations';
+import {
+    AnnotationsResponse,
+    useLatestAnnotations,
+    useLatestAnnotationsFetcher
+} from 'api/hooks/annotations';
 import {
     getPageNumbersToKeepInCache,
     mergeCachedArraysBasedOnCachedNumbers
 } from '../task-annotator-utils';
 import { TAnnotationsLazyLoadingParams } from './types';
 import { useCachedDataPagesRange } from './use-cached-data-pages-range';
+
+const intersect = (a: number[], b: number[]) => {
+    const setB = new Set(b);
+    return [...new Set(a)].filter((x) => setB.has(x));
+};
+
+const mergeAnnotationsData = (
+    oldData: AnnotationsResponse,
+    newData: AnnotationsResponse,
+    pageNumbersToKeepInCache: Set<number>
+) => ({
+    ...oldData,
+    ...newData,
+    pages: mergeCachedArraysBasedOnCachedNumbers(
+        oldData.pages,
+        newData.pages,
+        pageNumbersToKeepInCache,
+        ({ page_num }) => page_num
+    ),
+    validated: mergeCachedArraysBasedOnCachedNumbers(
+        oldData.validated,
+        newData.validated,
+        pageNumbersToKeepInCache
+    ),
+    failed_validation_pages: mergeCachedArraysBasedOnCachedNumbers(
+        oldData.failed_validation_pages,
+        newData.failed_validation_pages,
+        pageNumbersToKeepInCache
+    )
+});
 
 export const useAnnotationsLazyLoading = (
     {
@@ -28,68 +62,69 @@ export const useAnnotationsLazyLoading = (
     const getFileId = () => (task ? task.file.id : fileMetaInfo?.id);
 
     const { cachedPageIndexesRange, setCachedRange } = useCachedDataPagesRange();
+    const latestAnnotationsQueryParams = {
+        jobId: getJobId(),
+        fileId: getFileId(),
+        revisionId,
+        pageNumbers: nextLoadingPageNumbers,
+        userId: job?.validation_type === 'extensive_coverage' && !revisionId ? task?.user_id : ''
+    };
 
-    const latestAnnotationsQuery = useLatestAnnotations(
-        {
-            jobId: getJobId(),
-            fileId: getFileId(),
-            revisionId,
-            pageNumbers: nextLoadingPageNumbers,
-            userId:
-                job?.validation_type === 'extensive_coverage' && !revisionId ? task?.user_id : ''
-        },
-        {
-            enabled:
-                hookEnabled &&
-                Boolean(task || job || revisionId) &&
-                nextLoadingPageNumbers.length > 0,
-            onSuccess(newData) {
-                setLatestAnnotationsResultData((oldData) => {
-                    setCachedRange(availableRenderedPagesRange, nextLoadingPagesRange);
+    const latestAnnotationsQuery = useLatestAnnotations(latestAnnotationsQueryParams, {
+        enabled:
+            hookEnabled && Boolean(task || job || revisionId) && nextLoadingPageNumbers.length > 0,
+        onSuccess(newData) {
+            setLatestAnnotationsResultData((oldData) => {
+                setCachedRange(availableRenderedPagesRange, nextLoadingPagesRange);
 
-                    if (!oldData) {
-                        return newData;
-                    }
+                if (!oldData) {
+                    return newData;
+                }
 
-                    const pageNumbersToKeepInCache = getPageNumbersToKeepInCache(
-                        pageNumbers,
-                        availableRenderedPagesRange
-                    );
+                const pageNumbersToKeepInCache = getPageNumbersToKeepInCache(
+                    pageNumbers,
+                    availableRenderedPagesRange
+                );
 
-                    // unset selected annotation if it's not in cache (we render only items which are in cache)
-                    setSelectedAnnotation((prevSelectedAnnotation) => {
-                        const noSelectedAnnotationInCache =
-                            prevSelectedAnnotation &&
-                            !pageNumbersToKeepInCache.has(prevSelectedAnnotation.pageNum!);
+                // unset selected annotation if it's not in cache (we render only items which are in cache)
+                setSelectedAnnotation((prevSelectedAnnotation) => {
+                    const noSelectedAnnotationInCache =
+                        prevSelectedAnnotation &&
+                        !pageNumbersToKeepInCache.has(prevSelectedAnnotation.pageNum!);
 
-                        return noSelectedAnnotationInCache ? undefined : prevSelectedAnnotation;
-                    });
-
-                    // merge old cached data with the new received data
-                    return {
-                        ...oldData,
-                        ...newData,
-                        pages: mergeCachedArraysBasedOnCachedNumbers(
-                            oldData.pages,
-                            newData.pages,
-                            pageNumbersToKeepInCache,
-                            ({ page_num }) => page_num
-                        ),
-                        validated: mergeCachedArraysBasedOnCachedNumbers(
-                            oldData.validated,
-                            newData.validated,
-                            pageNumbersToKeepInCache
-                        ),
-                        failed_validation_pages: mergeCachedArraysBasedOnCachedNumbers(
-                            oldData.failed_validation_pages,
-                            newData.failed_validation_pages,
-                            pageNumbersToKeepInCache
-                        )
-                    };
+                    return noSelectedAnnotationInCache ? undefined : prevSelectedAnnotation;
                 });
-            }
-        }
-    );
 
-    return { latestAnnotationsQuery, latestAnnotationsResultData, cachedPageIndexesRange };
+                // merge old cached data with the new received data
+                return mergeAnnotationsData(oldData, newData, pageNumbersToKeepInCache);
+            });
+        }
+    });
+
+    const latestAnnotationsFetcher = useLatestAnnotationsFetcher();
+    const refetchLatestAnnotationsIfNeeded = async (pageNumbersToRefetch: number[]) => {
+        const cachedPageNumbers = pageNumbers.slice(
+            cachedPageIndexesRange.begin,
+            cachedPageIndexesRange.end + 1
+        );
+        const pageNumbersToFetch = intersect(cachedPageNumbers, pageNumbersToRefetch);
+
+        if (pageNumbersToFetch.length > 0) {
+            const newData = await latestAnnotationsFetcher({
+                ...latestAnnotationsQueryParams,
+                pageNumbers: pageNumbersToFetch
+            });
+
+            setLatestAnnotationsResultData((oldData) =>
+                mergeAnnotationsData(oldData!, newData, new Set(cachedPageNumbers))
+            );
+        }
+    };
+
+    return {
+        latestAnnotationsQuery,
+        latestAnnotationsResultData,
+        refetchLatestAnnotationsIfNeeded,
+        cachedPageIndexesRange
+    };
 };

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
@@ -73,6 +73,7 @@ export const useAnnotationsLazyLoading = (
     const latestAnnotationsQuery = useLatestAnnotations(latestAnnotationsQueryParams, {
         enabled:
             hookEnabled && Boolean(task || job || revisionId) && nextLoadingPageNumbers.length > 0,
+        cacheTime: 0,
         onSuccess(newData) {
             setLatestAnnotationsResultData((oldData) => {
                 setCachedRange(availableRenderedPagesRange, nextLoadingPagesRange);

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
@@ -4,7 +4,6 @@ import {
     getPageNumbersToKeepInCache,
     mergeCachedArraysBasedOnCachedNumbers
 } from '../task-annotator-utils';
-import { PageInfo } from 'api/typings';
 import { TAnnotationsLazyLoadingParams } from './types';
 import { useCachedDataPagesRange } from './use-cached-data-pages-range';
 
@@ -70,7 +69,7 @@ export const useAnnotationsLazyLoading = (
                     return {
                         ...oldData,
                         ...newData,
-                        pages: mergeCachedArraysBasedOnCachedNumbers<PageInfo>(
+                        pages: mergeCachedArraysBasedOnCachedNumbers(
                             oldData.pages,
                             newData.pages,
                             pageNumbersToKeepInCache,

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-annotations-lazy-loading.ts
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { AnnotationsResponse, useLatestAnnotations } from 'api/hooks/annotations';
+import {
+    getPageNumbersToKeepInCache,
+    mergeCachedArraysBasedOnCachedNumbers
+} from '../task-annotator-utils';
+import { PageInfo } from 'api/typings';
+import { TAnnotationsLazyLoadingParams } from './types';
+import { useCachedDataPagesRange } from './use-cached-data-pages-range';
+
+export const useAnnotationsLazyLoading = (
+    {
+        task,
+        job,
+        jobId,
+        fileMetaInfo,
+        revisionId,
+        nextLoadingPageNumbers,
+        pageNumbers,
+        availableRenderedPagesRange,
+        nextLoadingPagesRange,
+        setSelectedAnnotation
+    }: TAnnotationsLazyLoadingParams,
+    { enabled: hookEnabled }: { enabled: boolean }
+) => {
+    const [latestAnnotationsResultData, setLatestAnnotationsResultData] =
+        useState<AnnotationsResponse>();
+    const getJobId = () => (task ? task.job.id : jobId);
+    const getFileId = () => (task ? task.file.id : fileMetaInfo?.id);
+
+    const { cachedPageIndexesRange, setCachedRange } = useCachedDataPagesRange();
+
+    const latestAnnotationsQuery = useLatestAnnotations(
+        {
+            jobId: getJobId(),
+            fileId: getFileId(),
+            revisionId,
+            pageNumbers: nextLoadingPageNumbers,
+            userId:
+                job?.validation_type === 'extensive_coverage' && !revisionId ? task?.user_id : ''
+        },
+        {
+            enabled:
+                hookEnabled &&
+                Boolean(task || job || revisionId) &&
+                nextLoadingPageNumbers.length > 0,
+            onSuccess(newData) {
+                setLatestAnnotationsResultData((oldData) => {
+                    setCachedRange(availableRenderedPagesRange, nextLoadingPagesRange);
+
+                    if (!oldData) {
+                        return newData;
+                    }
+
+                    const pageNumbersToKeepInCache = getPageNumbersToKeepInCache(
+                        pageNumbers,
+                        availableRenderedPagesRange
+                    );
+
+                    // unset selected annotation if it's not in cache (we render only items which are in cache)
+                    setSelectedAnnotation((prevSelectedAnnotation) => {
+                        const noSelectedAnnotationInCache =
+                            prevSelectedAnnotation &&
+                            !pageNumbersToKeepInCache.has(prevSelectedAnnotation.pageNum!);
+
+                        return noSelectedAnnotationInCache ? undefined : prevSelectedAnnotation;
+                    });
+
+                    // merge old cached data with the new received data
+                    return {
+                        ...oldData,
+                        ...newData,
+                        pages: mergeCachedArraysBasedOnCachedNumbers<PageInfo>(
+                            oldData.pages,
+                            newData.pages,
+                            pageNumbersToKeepInCache,
+                            ({ page_num }) => page_num
+                        ),
+                        validated: mergeCachedArraysBasedOnCachedNumbers(
+                            oldData.validated,
+                            newData.validated,
+                            pageNumbersToKeepInCache
+                        ),
+                        failed_validation_pages: mergeCachedArraysBasedOnCachedNumbers(
+                            oldData.failed_validation_pages,
+                            newData.failed_validation_pages,
+                            pageNumbersToKeepInCache
+                        )
+                    };
+                });
+            }
+        }
+    );
+
+    return { latestAnnotationsQuery, latestAnnotationsResultData, cachedPageIndexesRange };
+};

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-cached-data-pages-range.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-cached-data-pages-range.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+import { TRange } from './types';
+
+export const useCachedDataPagesRange = () => {
+    const [cachedPageIndexesRange, setCachedPageIndexesRange] = useState({ begin: -1, end: -1 });
+
+    return {
+        cachedPageIndexesRange,
+        setCachedRange: (renderedPagesRange: TRange, loadingPagesRange: TRange) => {
+            setCachedPageIndexesRange({
+                begin: Math.min(loadingPagesRange.begin, renderedPagesRange.begin),
+                end: Math.max(loadingPagesRange.end, renderedPagesRange.end)
+            });
+        }
+    };
+};

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-tokens-lazy-loading.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-tokens-lazy-loading.ts
@@ -1,0 +1,59 @@
+import { useTokens } from 'api/hooks/tokens';
+import { useState } from 'react';
+import {
+    getPageNumbersToKeepInCache,
+    mergeCachedArraysBasedOnCachedNumbers
+} from '../task-annotator-utils';
+import { PageInfo } from 'api/typings';
+import { TTokensLazyLoadingParams } from './types';
+import { useCachedDataPagesRange } from './use-cached-data-pages-range';
+
+export const useTokensLazyLoading = (
+    {
+        task,
+        fileMetaInfo,
+        nextLoadingPageNumbers,
+        pageNumbers,
+        availableRenderedPagesRange,
+        nextLoadingPagesRange
+    }: TTokensLazyLoadingParams,
+    { enabled: hookEnabled }: { enabled: boolean }
+) => {
+    const getFileId = () => (task ? task.file.id : fileMetaInfo?.id);
+    const [tokenPages, setTokenPages] = useState<PageInfo[]>([]);
+
+    const { cachedPageIndexesRange, setCachedRange } = useCachedDataPagesRange();
+
+    const tokenQuery = useTokens(
+        {
+            fileId: getFileId(),
+            pageNumbers: nextLoadingPageNumbers
+        },
+        {
+            enabled: hookEnabled && nextLoadingPageNumbers.length > 0,
+            onSuccess: (newData) => {
+                setTokenPages((oldData) => {
+                    setCachedRange(availableRenderedPagesRange, nextLoadingPagesRange);
+
+                    if (!oldData) {
+                        return newData;
+                    }
+
+                    const pageNumbersToKeepInCache = getPageNumbersToKeepInCache(
+                        pageNumbers,
+                        availableRenderedPagesRange
+                    );
+
+                    return mergeCachedArraysBasedOnCachedNumbers(
+                        oldData,
+                        newData,
+                        pageNumbersToKeepInCache,
+                        (page) => page.page_num
+                    );
+                });
+            }
+        }
+    );
+
+    return { tokenQuery, tokenPages, cachedPageIndexesRange };
+};

--- a/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-tokens-lazy-loading.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-data-lazy-loading/use-tokens-lazy-loading.ts
@@ -31,6 +31,7 @@ export const useTokensLazyLoading = (
         },
         {
             enabled: hookEnabled && nextLoadingPageNumbers.length > 0,
+            cacheTime: 0,
             onSuccess: (newData) => {
                 setTokenPages((oldData) => {
                     setCachedRange(availableRenderedPagesRange, nextLoadingPagesRange);

--- a/web/src/connectors/task-annotator-connector/use-document-links.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-links.ts
@@ -13,10 +13,10 @@ export interface DocumentLinksValue {
     setDocumentLinksChanged?: Dispatch<SetStateAction<boolean>>;
 }
 
-export const useDocumentLinks = (linksFromApi?: DocumentLink[]): DocumentLinksValue => {
-    const [selectedRelatedDoc, setSelectedRelatedDoc] = useState<FileDocument | undefined>(
-        undefined
-    );
+export const useDocumentLinks = (
+    setSelectedRelatedDoc: Dispatch<SetStateAction<FileDocument | undefined>>,
+    linksFromApi?: DocumentLink[]
+): DocumentLinksValue => {
     const [documentLinks, setDocumentLinks] = useState<DocumentLinkWithName[]>();
     const [documentLinksChanged, setDocumentLinksChanged] = useState(false);
 
@@ -79,10 +79,9 @@ export const useDocumentLinks = (linksFromApi?: DocumentLink[]): DocumentLinksVa
             linksToApi,
             onLinkChanged,
             onRelatedDocClick,
-            selectedRelatedDoc,
             setDocumentLinksChanged
         }),
-        [documentLinks, documentLinksChanged, linksToApi, selectedRelatedDoc]
+        [documentLinks, documentLinksChanged, linksToApi]
     );
 };
 

--- a/web/src/connectors/task-annotator-connector/use-validation.tsx
+++ b/web/src/connectors/task-annotator-connector/use-validation.tsx
@@ -7,7 +7,6 @@ import React, {
     useMemo,
     useState
 } from 'react';
-import { UseQueryResult } from 'react-query';
 import { isEmpty } from 'lodash';
 
 import { Task, TTaskUsers } from 'api/typings/tasks';
@@ -29,7 +28,7 @@ import { showError } from 'shared/components/notifications';
 import { getError } from 'shared/helpers/get-error';
 
 export type ValidationParams = {
-    latestAnnotationsResult: UseQueryResult<AnnotationsResponse, unknown>;
+    refetchLatestAnnotations: (pageNumbers: number[]) => Promise<void>;
     latestAnnotationsResultData: AnnotationsResponse | undefined;
     task?: Task;
     currentPage: number;
@@ -69,7 +68,7 @@ export type ValidationValues = {
 };
 
 export const useValidation = ({
-    latestAnnotationsResult,
+    refetchLatestAnnotations,
     latestAnnotationsResultData,
     task,
     currentPage,
@@ -228,7 +227,7 @@ export const useValidation = ({
             onCloseDataTab();
             onSaveTaskSuccess();
 
-            latestAnnotationsResult.refetch();
+            refetchLatestAnnotations(pages.map(({ page_num }) => page_num));
             setAnnotationSaved(true);
         } catch (error) {
             onSaveTaskError(error as ApiError);
@@ -238,7 +237,7 @@ export const useValidation = ({
         annDataAttrs,
         annotationsChanges,
         editedPages,
-        latestAnnotationsResult,
+        refetchLatestAnnotations,
         latestAnnotationsResultData,
         onCloseDataTab,
         onSaveTaskError,

--- a/web/src/connectors/task-annotator-connector/use-validation.tsx
+++ b/web/src/connectors/task-annotator-connector/use-validation.tsx
@@ -30,13 +30,14 @@ import { getError } from 'shared/helpers/get-error';
 
 export type ValidationParams = {
     latestAnnotationsResult: UseQueryResult<AnnotationsResponse, unknown>;
+    latestAnnotationsResultData: AnnotationsResponse | undefined;
     task?: Task;
     currentPage: number;
     onCloseDataTab: () => void;
     isOwner: boolean;
     taskUsers: MutableRefObject<TTaskUsers>;
     onSaveTask: () => void;
-    allAnnotations: Record<number, Annotation[]>;
+    annotationsChanges: Record<number, Annotation[]>;
     tokensByPages: Record<number, PageToken[]>;
     tokenPages?: PageInfo[];
     annDataAttrs: Record<number, Array<CategoryDataAttributeWithValue>>;
@@ -69,13 +70,14 @@ export type ValidationValues = {
 
 export const useValidation = ({
     latestAnnotationsResult,
+    latestAnnotationsResultData,
     task,
     currentPage,
     taskUsers,
     isOwner,
     onCloseDataTab,
     onSaveTask,
-    allAnnotations,
+    annotationsChanges,
     tokensByPages,
     tokenPages,
     annDataAttrs,
@@ -190,14 +192,14 @@ export const useValidation = ({
     const addAnnotationMutation = useAddAnnotationsMutation();
 
     const onSaveEditClick = async () => {
-        if (!task || !latestAnnotationsResult.data || !tokenPages) return;
+        if (!task || !latestAnnotationsResultData || !tokenPages) return;
         setPages(invalidPages, setInvalidPages);
         setPages(validPages, setValidPages);
 
-        let { revision } = latestAnnotationsResult.data;
+        let { revision } = latestAnnotationsResultData;
         const pages = mapModifiedAnnotationPagesToApi(
             editedPages,
-            allAnnotations,
+            annotationsChanges,
             tokensByPages,
             tokenPages,
             annDataAttrs,

--- a/web/src/shared/components/annotator/utils/use-annotation-links.ts
+++ b/web/src/shared/components/annotator/utils/use-annotation-links.ts
@@ -17,7 +17,6 @@ export const useAnnotationsLinks = (
     category: Category | undefined,
     current_page: number | undefined,
     selectionType: AnnotationBoundType | AnnotationLinksBoundType | AnnotationImageToolType,
-    allAnnotations: Record<number, Annotation[]>,
     onAnnotationEdited: (
         prevPage: number,
         links: Pick<Annotation, 'links'>,
@@ -67,8 +66,6 @@ export const useAnnotationsLinks = (
         prevPage.current = selectedAnn?.pageNum;
         prevSelectedAnnotation.current = selectedAnn;
     }, [selectedAnn]);
-
-    return allAnnotations;
 };
 
 export const getAnnotationElementId = (pageNum: number, elmId: string | number): string => {

--- a/web/src/shared/helpers/scroll-into-view-if-needed.ts
+++ b/web/src/shared/helpers/scroll-into-view-if-needed.ts
@@ -1,0 +1,34 @@
+const isPointInsideRect = (point: { x: number; y: number }, rect: DOMRect): boolean => {
+    return (
+        point.x >= rect.left &&
+        point.x <= rect.right &&
+        point.y >= rect.top &&
+        point.y <= rect.bottom
+    );
+};
+
+const isRectIsFullyInAnotherRect = (rectIn: DOMRect, rectOut: DOMRect): boolean => {
+    return (
+        isPointInsideRect({ x: rectIn.left, y: rectIn.top }, rectOut) &&
+        isPointInsideRect({ x: rectIn.right, y: rectIn.top }, rectOut) &&
+        isPointInsideRect({ x: rectIn.right, y: rectIn.bottom }, rectOut) &&
+        isPointInsideRect({ x: rectIn.left, y: rectIn.bottom }, rectOut)
+    );
+};
+
+/**
+ * Scrolls [childElement] into the visible area of [parentElement] if it's
+ * not already within the visible area of the browser window.
+ * @param parentElement
+ * @param childElement
+ */
+export const scrollIntoViewIfNeeded = (parentElement: Element, childElement: Element) => {
+    const isVisible = isRectIsFullyInAnotherRect(
+        childElement.getBoundingClientRect(),
+        parentElement.getBoundingClientRect()
+    );
+
+    if (!isVisible) {
+        childElement.scrollIntoView();
+    }
+};

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2603,7 +2603,15 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-window@^1.8.5":
+"@types/react-window-infinite-loader@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-window-infinite-loader/-/react-window-infinite-loader-1.0.6.tgz#d7b23b4afaa1e0e2050876b766c3ea19f748f549"
+  integrity sha512-V8g8sBDLVeJJAfEENJS7VXZK+DRJ+jzPNtk8jpj2G+obhf+iqGNUDGwNWCbBhLiD+KpHhf3kWQlKBRi0tAeU4Q==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-window" "*"
+
+"@types/react-window@*", "@types/react-window@^1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
   integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
@@ -11562,6 +11570,11 @@ react-virtualized@^9.22.3:
     prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
 
+react-window-infinite-loader@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/react-window-infinite-loader/-/react-window-infinite-loader-1.0.9.tgz#d861c03d5cbc550e2f185371af820fd22d46c099"
+  integrity sha512-5Hg89IdU4Vrp0RT8kZYKeTIxWZYhNkVXeI1HbKo01Vm/Z7qztDvXljwx16sMzsa9yapRJQW3ODZfMUw38SOWHw==
+
 react-window@^1.8.9:
   version "1.8.9"
   resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.9.tgz#24bc346be73d0468cdf91998aac94e32bc7fa6a8"
@@ -13490,6 +13503,11 @@ use-callback-ref@^1.2.5:
   version "1.2.5"
   resolved "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz"
   integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
+
+use-debounce@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-9.0.4.tgz#51d25d856fbdfeb537553972ce3943b897f1ac85"
+  integrity sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==
 
 use-resize-observer@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
The goal of this PR is to improve performance of loading big PDF files (1000+) pages where we may potentially have up to 50 annotations. Unfortunately, this PR is quite big because during development there were a lot of different experiments which touched different parts of the app. It might be possible to split it into smaller PRs and merge them separately but this may require also a lot of time to re-test a lot of stuff for split functionality (it's easy to break something). Cos of this I propose to keep this solid PR.

In the future, it would be a good step to have refactoring mostly for the existing big react context because it contains tons of logic for different document modes  like "Validation only" / "Cross validation" etc. This modes may have own context/own hooks/own components.