### PR TITLE
fix: Tooltip With Very Long List Of Pages

### DIFF
--- a/web/src/components/task/task-sidebar/finish-button/utils.ts
+++ b/web/src/components/task/task-sidebar/finish-button/utils.ts
@@ -1,14 +1,12 @@
 const LISTED_PAGES_LIMIT = 10;
-const SLICE_START_INDEX = 0;
-const SLICE_END_INDEX = LISTED_PAGES_LIMIT - 1;
 
-const getPagesList = (pages: number[]) => pages?.join(', ');
+const getPagesList = (pages: number[]) => pages.join(', ');
 
 const getAboveLimitPagesCount = (pages: number[]) => pages.length - LISTED_PAGES_LIMIT;
 
-const getVisiblePagesString = (pages: number[]) => getPagesList(getVisiblePagesArray(pages));
+const getVisiblePagesArray = (pages: number[]) => pages.slice(0, LISTED_PAGES_LIMIT);
 
-const getVisiblePagesArray = (pages: number[]) => pages.slice(SLICE_START_INDEX, SLICE_END_INDEX);
+const getVisiblePagesString = (pages: number[]) => getPagesList(getVisiblePagesArray(pages));
 
 const listRemainingPages = (pages: number[]) => {
     if (pages.length > LISTED_PAGES_LIMIT) {

--- a/web/src/components/task/task-sidebar/finish-button/utils.ts
+++ b/web/src/components/task/task-sidebar/finish-button/utils.ts
@@ -1,7 +1,29 @@
+const LISTED_PAGES_LIMIT = 10;
+const SLICE_START_INDEX = 0;
+const SLICE_END_INDEX = LISTED_PAGES_LIMIT - 1;
+
+const getPagesList = (pages: number[]) => pages?.join(', ');
+
+const getAboveLimitPagesCount = (pages: number[]) => pages.length - LISTED_PAGES_LIMIT;
+
+const getVisiblePagesString = (pages: number[]) => getPagesList(getVisiblePagesArray(pages));
+
+const getVisiblePagesArray = (pages: number[]) => pages.slice(SLICE_START_INDEX, SLICE_END_INDEX);
+
+const listRemainingPages = (pages: number[]) => {
+    if (pages.length > LISTED_PAGES_LIMIT) {
+        const visiblePages = getVisiblePagesString(pages);
+        const remainingPagesAboveLimit = getAboveLimitPagesCount(pages);
+
+        return `${visiblePages} and ${remainingPagesAboveLimit} more.`;
+    }
+    return getPagesList(pages);
+};
+
 export const createTooltip = (isExtCov: boolean, notProcessedPages: number[]): string => {
     return isExtCov
         ? `Please wait for all annotators to finish their tasks`
-        : `Please validate all page to finish task. Remaining pages: ${notProcessedPages?.join(
-              ', '
+        : `Please validate all page to finish task. Remaining pages: ${listRemainingPages(
+              notProcessedPages
           )}`;
 };


### PR DESCRIPTION
This PR addresses the issue of a very long list of remaining pages appearing on the tooltip of the finish validation button.

It consists on the creation of a set of utils that will handle the cases when more than 10 pages are remaining