### PR TITLE
fix: Tootips for uncovered Task Status cases

### DIFF
--- a/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
@@ -63,7 +63,7 @@ export const FinishButton: FC<TaskSidebarProps> = ({
 
     const tooltipContent = createTooltip({
         isDisabled,
-        isExtCov: jobType !== 'extensive_coverage',
+        isExtensiveCoverage: jobType !== 'extensive_coverage',
         notProcessedPages,
         taskStatus
     });

--- a/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
@@ -39,7 +39,8 @@ export const FinishButton: FC<TaskSidebarProps> = ({
     onFinishValidation,
     onAnnotationTaskFinish,
     onFinishSplitValidation,
-    jobType
+    jobType,
+    taskStatus
 }) => {
     const [redirectionSettings, setRedirectionSettings] = useState(
         localStorage.getItem('submitted-task-redirection-page') ?? 'tasks'
@@ -60,9 +61,12 @@ export const FinishButton: FC<TaskSidebarProps> = ({
             (isValidation && !touchedPagesCount && !editedPagesCount);
     }
 
-    const tooltipContent = !isDisabled
-        ? null
-        : createTooltip(jobType === 'extensive_coverage', notProcessedPages);
+    const tooltipContent = createTooltip({
+        isDisabled,
+        isExtCov: jobType !== 'extensive_coverage',
+        notProcessedPages,
+        taskStatus
+    });
 
     const redirectSettingsDataSource = useArrayDataSource(
         {

--- a/web/src/components/task/task-sidebar/finish-button/utils.ts
+++ b/web/src/components/task/task-sidebar/finish-button/utils.ts
@@ -1,3 +1,5 @@
+import { TaskStatus } from 'api/typings/tasks';
+
 const LISTED_PAGES_LIMIT = 10;
 
 const getPagesList = (pages: number[]) => pages.join(', ');
@@ -18,10 +20,32 @@ const listRemainingPages = (pages: number[]) => {
     return getPagesList(pages);
 };
 
-export const createTooltip = (isExtCov: boolean, notProcessedPages: number[]): string => {
-    return isExtCov
-        ? `Please wait for all annotators to finish their tasks`
-        : `Please validate all page to finish task. Remaining pages: ${listRemainingPages(
-              notProcessedPages
-          )}`;
+interface CreateTooltipArgs {
+    isExtCov: boolean;
+    notProcessedPages: number[];
+    isDisabled: boolean;
+    taskStatus?: TaskStatus;
+}
+
+export const FINISHED_TASK_TOOLTIP_TEXT =
+    'This annotation task is done. To continue annotating this document create a new task';
+
+export const createTooltip = ({
+    isDisabled,
+    taskStatus,
+    isExtCov,
+    notProcessedPages
+}: CreateTooltipArgs) => {
+    switch (true) {
+        case !isDisabled || taskStatus === 'Pending':
+            return null;
+        case taskStatus === 'Finished':
+            return FINISHED_TASK_TOOLTIP_TEXT;
+        default:
+            return isExtCov
+                ? 'Please wait for all annotators to finish their tasks'
+                : `Please validate all page to finish task. Remaining pages: ${listRemainingPages(
+                      notProcessedPages
+                  )}`;
+    }
 };

--- a/web/src/components/task/task-sidebar/finish-button/utils.ts
+++ b/web/src/components/task/task-sidebar/finish-button/utils.ts
@@ -21,7 +21,7 @@ const listRemainingPages = (pages: number[]) => {
 };
 
 interface CreateTooltipArgs {
-    isExtCov: boolean;
+    isExtensiveCoverage: boolean;
     notProcessedPages: number[];
     isDisabled: boolean;
     taskStatus?: TaskStatus;
@@ -33,19 +33,17 @@ export const FINISHED_TASK_TOOLTIP_TEXT =
 export const createTooltip = ({
     isDisabled,
     taskStatus,
-    isExtCov,
+    isExtensiveCoverage,
     notProcessedPages
 }: CreateTooltipArgs) => {
-    switch (true) {
-        case !isDisabled || taskStatus === 'Pending':
-            return null;
-        case taskStatus === 'Finished':
-            return FINISHED_TASK_TOOLTIP_TEXT;
-        default:
-            return isExtCov
-                ? 'Please wait for all annotators to finish their tasks'
-                : `Please validate all page to finish task. Remaining pages: ${listRemainingPages(
-                      notProcessedPages
-                  )}`;
+    if (!isDisabled || taskStatus === 'Pending') {
+        return null;
+    } else if (taskStatus === 'Finished') {
+        return FINISHED_TASK_TOOLTIP_TEXT;
     }
+    return isExtensiveCoverage
+        ? 'Please wait for all annotators to finish their tasks'
+        : `Please validate all page to finish task. Remaining pages: ${listRemainingPages(
+              notProcessedPages
+          )}`;
 };

--- a/web/src/components/task/task-sidebar/task-sidebar.tsx
+++ b/web/src/components/task/task-sidebar/task-sidebar.tsx
@@ -43,6 +43,7 @@ import { ReactComponent as Copy } from '@epam/assets/icons/common/copy_content-1
 import { handleCopy } from 'shared/helpers/copy-text';
 
 import styles from './task-sidebar.module.scss';
+import { getSaveButtonTooltipContent } from './utils';
 
 type TaskSidebarProps = {
     jobSettings?: ReactElement;
@@ -337,6 +338,11 @@ const TaskSidebar: FC<TaskSidebarProps> = ({ jobSettings, viewMode, isNextTaskPr
         setIsHidden(!isHidden);
     };
 
+    const saveButtonTooltipContent = getSaveButtonTooltipContent(
+        isSaveButtonDisabled,
+        task?.status
+    );
+
     return (
         <Panel cx={styles.wrapper}>
             <Button
@@ -576,13 +582,7 @@ const TaskSidebar: FC<TaskSidebarProps> = ({ jobSettings, viewMode, isNextTaskPr
                         </div>
                     </div>
                     {task && ( // todo: add "EDIT ANNOTATION" button here if no task
-                        <Tooltip
-                            content={
-                                isSaveButtonDisabled
-                                    ? 'Please modify annotation to enable save button'
-                                    : ''
-                            }
-                        >
+                        <Tooltip content={saveButtonTooltipContent}>
                             <Button
                                 caption={SaveButton}
                                 fill="white"

--- a/web/src/components/task/task-sidebar/utils.ts
+++ b/web/src/components/task/task-sidebar/utils.ts
@@ -1,0 +1,18 @@
+import { TaskStatus } from 'api/typings/tasks';
+import { FINISHED_TASK_TOOLTIP_TEXT } from './finish-button/utils';
+
+export const getSaveButtonTooltipContent = (
+    isSaveButtonDisabled: boolean,
+    taskStatus?: TaskStatus
+) => {
+    switch (true) {
+        case isSaveButtonDisabled && taskStatus === 'Finished':
+            return FINISHED_TASK_TOOLTIP_TEXT;
+        case isSaveButtonDisabled && taskStatus === 'Pending':
+            return null;
+        case isSaveButtonDisabled:
+            return 'Please modify annotation to enable save button';
+        default:
+            return null;
+    }
+};

--- a/web/src/components/task/task-sidebar/utils.ts
+++ b/web/src/components/task/task-sidebar/utils.ts
@@ -5,14 +5,12 @@ export const getSaveButtonTooltipContent = (
     isSaveButtonDisabled: boolean,
     taskStatus?: TaskStatus
 ) => {
-    switch (true) {
-        case isSaveButtonDisabled && taskStatus === 'Finished':
-            return FINISHED_TASK_TOOLTIP_TEXT;
-        case isSaveButtonDisabled && taskStatus === 'Pending':
-            return null;
-        case isSaveButtonDisabled:
-            return 'Please modify annotation to enable save button';
-        default:
-            return null;
+    if (isSaveButtonDisabled && taskStatus === 'Finished') {
+        return FINISHED_TASK_TOOLTIP_TEXT;
+    } else if (isSaveButtonDisabled && taskStatus === 'Pending') {
+        return null;
+    } else if (isSaveButtonDisabled) {
+        return 'Please modify annotation to enable save button';
     }
+    return null;
 };

--- a/web/src/components/task/task-sidebar/utils.ts
+++ b/web/src/components/task/task-sidebar/utils.ts
@@ -5,9 +5,9 @@ export const getSaveButtonTooltipContent = (
     isSaveButtonDisabled: boolean,
     taskStatus?: TaskStatus
 ) => {
-    if (isSaveButtonDisabled && taskStatus === 'Finished') {
+    if (taskStatus === 'Finished') {
         return FINISHED_TASK_TOOLTIP_TEXT;
-    } else if (isSaveButtonDisabled && taskStatus === 'Pending') {
+    } else if (taskStatus === 'Pending') {
         return null;
     } else if (isSaveButtonDisabled) {
         return 'Please modify annotation to enable save button';


### PR DESCRIPTION
This PR addresses the issues raised about the Tooltips of the Finish and Save Button