### PR TITLE
fix: Introduces no-wrap for box annotation label

### DIFF
--- a/web/src/shared/components/annotator/components/box-annotation/box-annotation.module.scss
+++ b/web/src/shared/components/annotator/components/box-annotation/box-annotation.module.scss
@@ -14,6 +14,7 @@
         display: flex;
         align-items: center;
         user-select: none;
+        white-space: nowrap;
     }
 
     .labelDraggable {


### PR DESCRIPTION
This PR addresses the issue of wrapping text for the box annotation labels