### PR TITLE
fix: Edit Categories Modal

### DIFF
--- a/web/src/connectors/categories-modal-connector/categories-modal-connector.tsx
+++ b/web/src/connectors/categories-modal-connector/categories-modal-connector.tsx
@@ -107,11 +107,14 @@ export const ModalWithDisabledClickOutsideAndCross: FC<IProps> = ({
         value: getDefaultValues(categoryValue)
     });
 
+    const title = categoryValue ? 'Edit category' : 'Add new category';
+    const categoryIdClassName = categoryValue ? styles['hidden-category-id'] : '';
+
     return (
         <ModalBlocker disallowClickOutside blockerShadow="dark" {...props} abort={onClose}>
             <ModalWindow>
                 <Panel background="white">
-                    <ModalHeader title="Add new category" />
+                    <ModalHeader title={title} />
                     <ScrollBars hasTopShadow hasBottomShadow>
                         <FlexRow padding="24" vPadding="12">
                             <FlexCell grow={1}>
@@ -120,13 +123,15 @@ export const ModalWithDisabledClickOutsideAndCross: FC<IProps> = ({
                                 </LabeledInput>
                             </FlexCell>
                         </FlexRow>
-                        <FlexRow padding="24" vPadding="12">
-                            <FlexCell grow={1}>
-                                <LabeledInput isRequired label="Category Id">
-                                    <TextInput {...lens.prop('categoryId').toProps()} />
-                                </LabeledInput>
-                            </FlexCell>
-                        </FlexRow>
+                        <div className={categoryIdClassName}>
+                            <FlexRow padding="24" vPadding="12">
+                                <FlexCell grow={1}>
+                                    <LabeledInput isRequired={!categoryValue} label="Category Id">
+                                        <TextInput {...lens.prop('categoryId').toProps()} />
+                                    </LabeledInput>
+                                </FlexCell>
+                            </FlexRow>
+                        </div>
                         <FlexRow padding="24" vPadding="12">
                             <FlexCell grow={1}>
                                 <LabeledInput isRequired label="Color">

--- a/web/src/connectors/categories-modal-connector/categories-modal-connector.tsx
+++ b/web/src/connectors/categories-modal-connector/categories-modal-connector.tsx
@@ -108,7 +108,6 @@ export const ModalWithDisabledClickOutsideAndCross: FC<IProps> = ({
     });
 
     const title = categoryValue ? 'Edit category' : 'Add new category';
-    const categoryIdClassName = categoryValue ? styles['hidden-category-id'] : '';
 
     return (
         <ModalBlocker disallowClickOutside blockerShadow="dark" {...props} abort={onClose}>
@@ -123,7 +122,7 @@ export const ModalWithDisabledClickOutsideAndCross: FC<IProps> = ({
                                 </LabeledInput>
                             </FlexCell>
                         </FlexRow>
-                        <div className={categoryIdClassName}>
+                        {!categoryValue && (
                             <FlexRow padding="24" vPadding="12">
                                 <FlexCell grow={1}>
                                     <LabeledInput isRequired={!categoryValue} label="Category Id">
@@ -131,7 +130,8 @@ export const ModalWithDisabledClickOutsideAndCross: FC<IProps> = ({
                                     </LabeledInput>
                                 </FlexCell>
                             </FlexRow>
-                        </div>
+                        )}
+
                         <FlexRow padding="24" vPadding="12">
                             <FlexCell grow={1}>
                                 <LabeledInput isRequired label="Color">

--- a/web/src/connectors/categories-modal-connector/styles.module.scss
+++ b/web/src/connectors/categories-modal-connector/styles.module.scss
@@ -1,7 +1,3 @@
 .activate-checkbox-parent {
     margin: 10px 0;
 }
-
-.hidden-category-id {
-    display: none;
-}

--- a/web/src/connectors/categories-modal-connector/styles.module.scss
+++ b/web/src/connectors/categories-modal-connector/styles.module.scss
@@ -1,3 +1,7 @@
 .activate-checkbox-parent {
     margin: 10px 0;
 }
+
+.hidden-category-id {
+    display: none;
+}

--- a/web/src/connectors/categories-modal-connector/utils.ts
+++ b/web/src/connectors/categories-modal-connector/utils.ts
@@ -31,6 +31,7 @@ export const getFormSchema = (formValues: TFormValues): Metadata<TFormValues> =>
 
 export const getDefaultValues = (category: Category | undefined) => {
     const {
+        id,
         name,
         type,
         metadata,
@@ -39,11 +40,11 @@ export const getDefaultValues = (category: Category | undefined) => {
     } = category || {};
 
     return {
-        categoryId: '',
+        categoryId: id || '',
         name: name ?? '',
         parentId: parent,
         type: type ?? 'box',
-        withParentLabel: !parent,
+        withParentLabel: !!parent,
         color: metadata?.color ?? '',
         dataAttributes: dataAttributes ?? []
     };


### PR DESCRIPTION
This PR addresses the issues described of the edit categories modal

For the given context of editing an existing category:
- Adds a new class to hide category-id field
- Fixes utils the map existing category values to the form values
- Implements necessary changes on Modal component