### PR TITLE
 fix: confirm modal only on annotation finish

### DIFF
--- a/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
@@ -19,7 +19,9 @@ export const ConfirmModal = (modalProps: IModal<string>) => (
                 <ModalHeader title="Attention" onClose={() => modalProps.abort()} />
                 <ScrollBars hasTopShadow hasBottomShadow>
                     <FlexRow padding="24">
-                        <Text size="36">Are you sure you want to stop editing the document?</Text>
+                        <Text size="36">
+                            Are you sure you want to stop annotating this document?
+                        </Text>
                     </FlexRow>
                 </ScrollBars>
                 <ModalFooter>

--- a/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useState } from 'react';
 import { useArrayDataSource } from '@epam/uui';
 import { PickerInput, Button, ControlGroup, Tooltip } from '@epam/loveship';
 

--- a/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
@@ -73,15 +73,15 @@ export const FinishButton: FC<TaskSidebarProps> = ({
         []
     );
 
-    const finishingValidation = useCallback(() => {
+    const finishingValidation = () => {
         if (isValidation) {
             handleFinishValidation();
         } else {
             onAnnotationTaskFinish();
         }
-    }, [handleFinishValidation, onAnnotationTaskFinish, isValidation]);
+    };
 
-    const showConfirmModal = useCallback(() => {
+    const showConfirmModal = () => {
         if (confirmWindowNeed === 'true') {
             uuiModals
                 .show<string>((props) => <ConfirmModal {...props} />)
@@ -91,7 +91,7 @@ export const FinishButton: FC<TaskSidebarProps> = ({
         } else {
             finishingValidation();
         }
-    }, [confirmWindowNeed, finishingValidation, uuiModals]);
+    };
 
     return !isValidation && viewMode ? null : (
         <>

--- a/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
@@ -82,7 +82,7 @@ export const FinishButton: FC<TaskSidebarProps> = ({
     };
 
     const showConfirmModal = () => {
-        if (confirmWindowNeed === 'true') {
+        if (confirmWindowNeed === 'true' && !isValidation) {
             uuiModals
                 .show<string>((props) => <ConfirmModal {...props} />)
                 .then(() => {


### PR DESCRIPTION
Confirm modal only on when annotation finished. New text added in confirm modal.