### PR TITLE
fix: show "confirm" modal only when annotation is finished

### DIFF
--- a/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
@@ -19,7 +19,7 @@ export const ConfirmModal = (modalProps: IModal<string>) => (
                 <ModalHeader title="Attention" onClose={() => modalProps.abort()} />
                 <ScrollBars hasTopShadow hasBottomShadow>
                     <FlexRow padding="24">
-                        <Text size="36">Are you sure you want to stop editing the document?</Text>
+                        <Text size="36">Are you sure you want to stop annotating this document?</Text>
                     </FlexRow>
                 </ScrollBars>
                 <ModalFooter>

--- a/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
@@ -82,7 +82,7 @@ export const FinishButton: FC<TaskSidebarProps> = ({
     }, [handleFinishValidation, onAnnotationTaskFinish, isValidation]);
 
     const showConfirmModal = useCallback(() => {
-        if (confirmWindowNeed === 'true') {
+        if (confirmWindowNeed === 'true' && !isValidation) {
             uuiModals
                 .show<string>((props) => <ConfirmModal {...props} />)
                 .then(() => {


### PR DESCRIPTION
Confirm modal only when annotation finished. 
New text added to confirm modal.