### PR TITLE
chore: Improve code checkers for "web" folder

### DIFF
--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
     root: true, // Make sure eslint picks up the config at the root of the directory
     parser: '@typescript-eslint/parser',
     parserOptions: {
-        ecmaVersion: 2020, // Use the latest ecmascript standard
+        ecmaVersion: 'latest',
         sourceType: 'module', // Allows using import/export statements
         ecmaFeatures: {
             jsx: true // Enable JSX since we're using React
@@ -25,11 +25,12 @@ module.exports = {
         'eslint:recommended',
         'plugin:react/recommended',
         'plugin:jsx-a11y/recommended',
-        'plugin:prettier/recommended' // Make this the last element so prettier config overrides other formatting rules
+        'react-app',
+        'react-app/jest',
+        'plugin:react/jsx-runtime',
+        'prettier' // Make this the last element so prettier config overrides other formatting rules
     ],
     rules: {
-        'prettier/prettier': ['warn', {}, { usePrettierrc: true }], // Use our .prettierrc file as source
-        'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': 1,
         'no-debugger': 1,
         'jsx-a11y/no-static-element-interactions': 1,

--- a/web/config/jest/decorators/withRouter.tsx
+++ b/web/config/jest/decorators/withRouter.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { ReactElement } from 'react';
 import { Router } from 'react-router-dom';
 import { createBrowserHistory } from 'history';

--- a/web/package.json
+++ b/web/package.json
@@ -57,10 +57,12 @@
         "test": "react-scripts test",
         "test:ci": "yarn test --runInBand --passWithNoTests --verbose --watchAll=false",
         "test:coverage": "yarn test --coverage --watchAll=false",
-        "lint:js": "eslint . --ext .js,.ts,.tsx --max-warnings=0",
-        "lint:types": "tsc -p tsconfig.json --noEmit",
+        "check:all": "yarn check:lint-rules && yarn check:format && yarn check:types",
+        "check:lint-rules": "eslint . --ext .js,.ts,.tsx --max-warnings=0",
+        "check:format": "prettier ./src/**/*.{ts,tsx,js} --check",
+        "check:types": "tsc -p tsconfig.json --noEmit",
         "hooks:i": "npx simple-git-hooks",
-        "prettier": "prettier ./src/**/*.{ts,tsx,js} --write"
+        "fix:format": "prettier ./src/**/*.{ts,tsx,js} --write"
     },
     "browserslist": {
         "production": [
@@ -75,7 +77,7 @@
         ]
     },
     "simple-git-hooks": {
-        "pre-commit": "cd web && yarn lint:js --fix && yarn lint:types",
+        "pre-commit": "cd web && yarn check:all",
         "pre-push": "cd web && yarn test:ci"
     },
     "resolutions": {
@@ -96,7 +98,6 @@
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.25.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest-canvas-mock": "^2.5.2",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react';
 import { Redirect, Route, Switch, useHistory } from 'react-router-dom';
 

--- a/web/src/api/hooks/annotations.ts
+++ b/web/src/api/hooks/annotations.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { CategoryDataAttrType, MutationHookType, PageInfo, QueryHookType } from 'api/typings';
 import { Task } from 'api/typings/tasks';
 import { useMutation, useQuery, useQueryClient } from 'react-query';

--- a/web/src/api/hooks/api.ts
+++ b/web/src/api/hooks/api.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks, no-restricted-globals, eqeqeq */
 import { ApiError } from 'api/api-error';
 import { applyMocks } from 'api/mocks';
 import { HTTPRequestMethod } from 'api/typings';

--- a/web/src/api/hooks/assets.ts
+++ b/web/src/api/hooks/assets.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { QueryHookType } from '../typings';
 import { useQuery, useQueries } from 'react-query';
 import { useBadgerFetch } from './api';

--- a/web/src/api/hooks/auth.ts
+++ b/web/src/api/hooks/auth.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     AuthResult,
     AuthResultRaw,

--- a/web/src/api/hooks/basements.ts
+++ b/web/src/api/hooks/basements.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     HTTPRequestMethod,
     MutationHookType,

--- a/web/src/api/hooks/bonds.ts
+++ b/web/src/api/hooks/bonds.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { BondToDatasetResponse } from 'api/typings/bonds';
 import { useBadgerFetch } from './api';
 

--- a/web/src/api/hooks/categories.ts
+++ b/web/src/api/hooks/categories.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks, @typescript-eslint/no-unused-expressions */
 import {
     Category,
     CreateCategory,

--- a/web/src/api/hooks/datasets.ts
+++ b/web/src/api/hooks/datasets.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     Dataset,
     FileDocument,

--- a/web/src/api/hooks/document.ts
+++ b/web/src/api/hooks/document.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     FileDocument,
     FilterWithDocumentExtraOption,

--- a/web/src/api/hooks/documents.ts
+++ b/web/src/api/hooks/documents.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import {
     FileDocument,

--- a/web/src/api/hooks/jobs.ts
+++ b/web/src/api/hooks/jobs.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     PagedResponse,
     SortingDirection,

--- a/web/src/api/hooks/models.ts
+++ b/web/src/api/hooks/models.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     Basement,
     Model,

--- a/web/src/api/hooks/pipelines.ts
+++ b/web/src/api/hooks/pipelines.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     MutationHookType,
     Operators,

--- a/web/src/api/hooks/reports.ts
+++ b/web/src/api/hooks/reports.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { HTTPRequestMethod, Report } from 'api/typings';
 import { useBadgerFetch } from './api';
 

--- a/web/src/api/hooks/search.ts
+++ b/web/src/api/hooks/search.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { Operators, PagedResponse, QueryHookType } from 'api/typings';
 import { useQuery } from 'react-query';
 import {

--- a/web/src/api/hooks/tasks.ts
+++ b/web/src/api/hooks/tasks.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { useContext } from 'react';
 import {
     Dataset,

--- a/web/src/api/hooks/taxons.ts
+++ b/web/src/api/hooks/taxons.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     FilterWithDocumentExtraOption,
     HTTPRequestMethod,

--- a/web/src/api/hooks/tokens.ts
+++ b/web/src/api/hooks/tokens.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { QueryHookType, PageInfo } from 'api/typings';
 import { useQuery } from 'react-query';
 import { useBadgerFetch } from './api';

--- a/web/src/api/hooks/users.ts
+++ b/web/src/api/hooks/users.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
     User,
     PagedResponse,

--- a/web/src/api/mocks/apply-mocks.js
+++ b/web/src/api/mocks/apply-mocks.js
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable eqeqeq */
 const isMocksAllowed = String(process.env.REACT_APP_ALLOW_MOCKS).toLocaleLowerCase() == 'true';
 
 module.exports = function (req, res, next) {

--- a/web/src/app-header.tsx
+++ b/web/src/app-header.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps, no-restricted-globals */
 import React, { useContext, useMemo, useCallback } from 'react';
 import {
     Dropdown,

--- a/web/src/components/basement/add-basement-settings/add-basement-settings.tsx
+++ b/web/src/components/basement/add-basement-settings/add-basement-settings.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useState } from 'react';
 import { LabeledInput, TextInput, Checkbox, Button } from '@epam/loveship';
 import { Form, ILens } from '@epam/uui';

--- a/web/src/components/basement/basement-argument/basement-argument.tsx
+++ b/web/src/components/basement/basement-argument/basement-argument.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import styles from './basement-argument.module.scss';
 import { Button, LabeledInput, TextInput } from '@epam/loveship';

--- a/web/src/components/basement/basement-popup/basement-popup.tsx
+++ b/web/src/components/basement/basement-popup/basement-popup.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Basement } from '../../../api/typings';
 import styles from './basement-popup.module.scss';

--- a/web/src/components/categories/categories-data-attributes/categories-data-attributes.tsx
+++ b/web/src/components/categories/categories-data-attributes/categories-data-attributes.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { useArrayDataSource } from '@epam/uui';
 import { CategoryDataAttrType, CategoryDataAttribute } from '../../../api/typings';

--- a/web/src/components/categories/categories-tab/categories-tab.tsx
+++ b/web/src/components/categories/categories-tab/categories-tab.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 import { useCategoriesTree } from '../categories-tree/use-categories-tree';

--- a/web/src/components/categories/categories-tree/categories-tree.tsx
+++ b/web/src/components/categories/categories-tree/categories-tree.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useCallback, useEffect, useState } from 'react';
 
 import { Category, CategoryNode } from 'api/typings';

--- a/web/src/components/categories/categories-tree/use-categories-tree.tsx
+++ b/web/src/components/categories/categories-tree/use-categories-tree.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useCategoriesByJob } from 'api/hooks/categories';
 import {
     CategoryNode,

--- a/web/src/components/dataset-picker/dataset-picker.tsx
+++ b/web/src/components/dataset-picker/dataset-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Panel, PickerInput } from '@epam/loveship';
 import { LazyDataSource } from '@epam/uui';

--- a/web/src/components/dataset/dataset-add-form.tsx
+++ b/web/src/components/dataset/dataset-add-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, ReactNode, useState } from 'react';
 import { FormSaveResponse, IModal, Metadata, useUuiContext, IFormApi } from '@epam/uui';
 import {

--- a/web/src/components/dataset/dataset-choose-form.tsx
+++ b/web/src/components/dataset/dataset-choose-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, ReactNode, useState, useCallback } from 'react';
 import { FormSaveResponse, IModal, Metadata, useUuiContext, ILens, IFormApi } from '@epam/uui';
 import {

--- a/web/src/components/dataset/dataset-row/dataset-row.tsx
+++ b/web/src/components/dataset/dataset-row/dataset-row.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React from 'react';
 import { useDeleteDatasetMutation } from 'api/hooks/datasets';
 import { Dataset } from 'api/typings';

--- a/web/src/components/dataset/delete-dataset/delete-dataset.tsx
+++ b/web/src/components/dataset/delete-dataset/delete-dataset.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { IconButton } from '@epam/loveship';
 import React, { FC } from 'react';
 import { ReactComponent as deleteIcon } from '@epam/assets/icons/common/content-clear-18.svg';

--- a/web/src/components/documents/document-card-view-item/document-card-view-item.tsx
+++ b/web/src/components/documents/document-card-view-item/document-card-view-item.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps*/
 import React, { FC, useEffect, useState } from 'react';
 import styles from './document-card-view-item.module.scss';
 import { IconButton, Dropdown, Checkbox } from '@epam/loveship';
@@ -86,7 +88,8 @@ export const DocumentCardViewItem: FC<DocumentCardViewProps> = ({
                     <div className={styles['card-item-main']}>
                         <div className={styles['header-container']}>
                             <div className={styles['card-item-title']}>{name}</div>
-                            {/* eslint-disable */}
+                            {/* temporary_disabled_rules */}
+                            {/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
                             <div
                                 onClick={(event) => {
                                     if (setSelectedFiles) {
@@ -112,7 +115,9 @@ export const DocumentCardViewItem: FC<DocumentCardViewProps> = ({
                                     }
                                 }}
                             >
-                               {!isPieces && <Checkbox value={chooseFile} onValueChange={() => {}} />}
+                                {!isPieces && (
+                                    <Checkbox value={chooseFile} onValueChange={() => {}} />
+                                )}
                             </div>
                         </div>
                         {jobs && jobs.length ? (

--- a/web/src/components/documents/documents-drop-zone/documents-drop-zone.tsx
+++ b/web/src/components/documents/documents-drop-zone/documents-drop-zone.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import { DropSpot, Text, Blocker, Panel } from '@epam/loveship';
 import { useAddFilesToDatasetMutation } from 'api/hooks/datasets';
 import { useUploadFilesMutation } from 'api/hooks/documents';

--- a/web/src/components/external-viewer-modal/external-viewer-popup.tsx
+++ b/web/src/components/external-viewer-modal/external-viewer-popup.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import { Panel, ModalHeader, ModalFooter, FlexRow, FlexSpacer, Button, Text } from '@epam/loveship';
 import React, { ReactElement, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';

--- a/web/src/components/external-viewer-modal/external-viewer-popup.tsx
+++ b/web/src/components/external-viewer-modal/external-viewer-popup.tsx
@@ -11,9 +11,9 @@ import { ALL_BUTTONS } from './buttons-config';
 import { Ketcher } from 'ketcher-core';
 import 'ketcher-react/dist/index.css';
 import styles from './external-viewer-popup.module.scss';
+import { CategoryDataAttrType } from 'api/typings';
 
 const structServiceProvider = new StandaloneStructServiceProvider();
-import { CategoryDataAttrType } from 'api/typings';
 
 const addLaTex = () => {
     let link = document.createElement('link');

--- a/web/src/components/file-upload/attached-files/attached-files.tsx
+++ b/web/src/components/file-upload/attached-files/attached-files.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { FileTag } from '../file-tag/file-tag';
 

--- a/web/src/components/file-upload/drop-zone/drop-zone.tsx
+++ b/web/src/components/file-upload/drop-zone/drop-zone.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useCallback, useState } from 'react';
 import { DropSpotRenderParams, Panel } from '@epam/loveship';
 

--- a/web/src/components/file-upload/file-tag/file-tag.tsx
+++ b/web/src/components/file-upload/file-tag/file-tag.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC, useCallback } from 'react';
 import { Tag, Text } from '@epam/loveship';
 

--- a/web/src/components/file-upload/upload-form/upload-form.tsx
+++ b/web/src/components/file-upload/upload-form/upload-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { Button, Text, Panel } from '@epam/loveship';
 import { DropSpot, UploadFileToggler } from '@epam/uui-components';

--- a/web/src/components/job/automatic-job/automatic-job.tsx
+++ b/web/src/components/job/automatic-job/automatic-job.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useContext } from 'react';
 import { Pipeline } from 'api/typings';
 import { JobValues } from 'connectors/edit-job-connector/edit-job-connector';

--- a/web/src/components/job/automatic-manual-job/automatic-manual-job.tsx
+++ b/web/src/components/job/automatic-manual-job/automatic-manual-job.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useContext } from 'react';
 import { Pipeline, Taxonomy, User } from 'api/typings';
 import { JobValues } from 'connectors/edit-job-connector/edit-job-connector';

--- a/web/src/components/job/automatic-manual-job/extensive-coverage-input/extensive-coverage-input.tsx
+++ b/web/src/components/job/automatic-manual-job/extensive-coverage-input/extensive-coverage-input.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { LabeledInput, NumericInput } from '@epam/loveship';
 import { ILens } from '@epam/uui';

--- a/web/src/components/job/deadline-picker/deadline-picker.tsx
+++ b/web/src/components/job/deadline-picker/deadline-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DatePicker, LabeledInput } from '@epam/loveship';
 import { ILens } from '@epam/uui';
 import { JobValues } from 'connectors/edit-job-connector/edit-job-connector';

--- a/web/src/components/job/edit-job-settings/edit-job-settings.tsx
+++ b/web/src/components/job/edit-job-settings/edit-job-settings.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, eqeqeq */
 import React, { FC } from 'react';
 import { Category, Pipeline, Taxonomy, User } from 'api/typings';
 import { JobValues } from 'connectors/edit-job-connector/edit-job-connector';

--- a/web/src/components/job/job-name/job-name.tsx
+++ b/web/src/components/job/job-name/job-name.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { ILens } from '@epam/uui';
 import { LabeledInput, TextInput } from '@epam/loveship';
 import { JobValues } from 'connectors/edit-job-connector/edit-job-connector';

--- a/web/src/components/job/pipeline-picker/pipeline-picker.tsx
+++ b/web/src/components/job/pipeline-picker/pipeline-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useState } from 'react';
 import { Pipeline } from 'api/typings';
 import { InfoIcon } from '../../../shared/components/info-icon/info-icon';

--- a/web/src/components/job/users-picker/users-picker.tsx
+++ b/web/src/components/job/users-picker/users-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { PickerInput, LabeledInput } from '@epam/loveship';
 import { IEditable, useArrayDataSource } from '@epam/uui';
 

--- a/web/src/components/job/users-pickers/users-pickers.tsx
+++ b/web/src/components/job/users-pickers/users-pickers.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { User, ValidationType } from 'api/typings';
 import { JobValues } from 'connectors/edit-job-connector/edit-job-connector';

--- a/web/src/components/job/validation-type-picker/validation-type-picker.tsx
+++ b/web/src/components/job/validation-type-picker/validation-type-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { PickerInput, LabeledInput } from '@epam/loveship';
 import { ILens, useArrayDataSource } from '@epam/uui';
 import { ValidationType } from 'api/typings';

--- a/web/src/components/language-picker/language-picker.tsx
+++ b/web/src/components/language-picker/language-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Panel, PickerInput } from '@epam/loveship';
 import { ArrayDataSource } from '@epam/uui';

--- a/web/src/components/model/add-model-data/add-model-data.tsx
+++ b/web/src/components/model/add-model-data/add-model-data.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useState } from 'react';
 import TrainModel from '../train-model/train-model';
 import UseExistingDataModel from '../use-existing-data-model/use-existing-data-model';

--- a/web/src/components/model/add-model-settings/add-model-settings.tsx
+++ b/web/src/components/model/add-model-settings/add-model-settings.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 import React, { FC, useEffect } from 'react';
 
 import { Basement, Category, Model } from 'api/typings';

--- a/web/src/components/model/basement-picker/basement-picker.tsx
+++ b/web/src/components/model/basement-picker/basement-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 
 import { Basement } from 'api/typings';

--- a/web/src/components/model/model-picker/model-picker.tsx
+++ b/web/src/components/model/model-picker/model-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Model } from 'api/typings';
 import { ModelValues } from '../model.models';

--- a/web/src/components/model/model-training-jobs/jobs-columns.tsx
+++ b/web/src/components/model/model-training-jobs/jobs-columns.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import { Text } from '@epam/loveship';
 import React from 'react';
 import { Job } from 'api/typings/jobs';

--- a/web/src/components/model/train-model-job/jobs-columns.tsx
+++ b/web/src/components/model/train-model-job/jobs-columns.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import { Text } from '@epam/loveship';
 import React from 'react';
 import { Job } from 'api/typings/jobs';

--- a/web/src/components/model/train-model-job/train-model-job.tsx
+++ b/web/src/components/model/train-model-job/train-model-job.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useMemo, useRef } from 'react';
 import {
     FilterWithDocumentExtraOption,

--- a/web/src/components/model/train-model-setting/train-model-setting.tsx
+++ b/web/src/components/model/train-model-setting/train-model-setting.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useState } from 'react';
 import { mapUndefString } from '../../../shared/helpers/utils';
 import { ModelValues } from '../model.models';

--- a/web/src/components/model/train-model/train-model.tsx
+++ b/web/src/components/model/train-model/train-model.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import TrainModelSetting from '../train-model-setting/train-model-setting';
 import TrainModelJob from '../train-model-job/train-model-job';

--- a/web/src/components/model/use-existing-data-model/use-existing-data-model.tsx
+++ b/web/src/components/model/use-existing-data-model/use-existing-data-model.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useState } from 'react';
 import { mapUndefString } from '../../../shared/helpers/utils';
 import { ModelValues } from '../model.models';

--- a/web/src/components/pipeline/add-pipeline-form.tsx
+++ b/web/src/components/pipeline/add-pipeline-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, useCallback } from 'react';
 import { ErrorNotification, SuccessNotification, Text } from '@epam/loveship';
 import { Form, INotification } from '@epam/uui';

--- a/web/src/components/pipeline/add-pipeline-settings/add-pipeline-settings.tsx
+++ b/web/src/components/pipeline/add-pipeline-settings/add-pipeline-settings.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useState } from 'react';
 import { PipelineValues } from 'components/pipeline/add-pipeline-form';
 import { pipelinesFetcher } from 'api/hooks/pipelines';

--- a/web/src/components/pipeline/add-pipeline-wizard-form/add-pipeline-wizard-form.tsx
+++ b/web/src/components/pipeline/add-pipeline-wizard-form/add-pipeline-wizard-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useMemo, useEffect, useState } from 'react';
 import { IFormApi } from '@epam/uui-core';
 import { Pipeline, Category, PipelineData, PipelineTypes } from 'api/typings';

--- a/web/src/components/pipeline/edit-step/add-node-form.tsx
+++ b/web/src/components/pipeline/edit-step/add-node-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import { StepFormConnector } from 'connectors/step-form-connector/step-form-connector';
 import React, { FC } from 'react';
 import { StepValues } from './edit-step';

--- a/web/src/components/pipeline/edit-step/edit-node-form.tsx
+++ b/web/src/components/pipeline/edit-step/edit-node-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import { StepFormConnector } from 'connectors/step-form-connector/step-form-connector';
 import React, { FC, useMemo } from 'react';
 import { StepValues } from './edit-step';

--- a/web/src/components/pipeline/edit-step/edit-step.tsx
+++ b/web/src/components/pipeline/edit-step/edit-step.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import { IconButton } from '@epam/loveship';
 import { PipelineTypes, Step } from 'api/typings';
 import React, { useState } from 'react';

--- a/web/src/components/pipeline/edit-step/node-actions.tsx
+++ b/web/src/components/pipeline/edit-step/node-actions.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { XYPosition } from 'react-flow-renderer';
 import styles from './edit-step.module.scss';

--- a/web/src/components/pipeline/edit-step/step-form-fields.tsx
+++ b/web/src/components/pipeline/edit-step/step-form-fields.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import { PickerInput, LabeledInput, TextInput, Button } from '@epam/loveship';
 import { IFormApi, useArrayDataSource } from '@epam/uui';
 import { useModelById } from 'api/hooks/models';

--- a/web/src/components/pipeline/pipeline-component/pipeline-component.tsx
+++ b/web/src/components/pipeline/pipeline-component/pipeline-component.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { PipelineData, Step } from 'api/typings';
 import { createFlowElements } from 'components/pipeline/pipeline-utils/create-flow-elements';
 import React, { useState, useEffect, useMemo, FC } from 'react';

--- a/web/src/components/pipeline/pipeline-component/use-pipeline-editor.ts
+++ b/web/src/components/pipeline/pipeline-component/use-pipeline-editor.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import { Category, Step } from 'api/typings';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Elements, FlowElement, FlowTransform, isNode, Node } from 'react-flow-renderer';

--- a/web/src/components/pipeline/pipeline-form-field/pipeline-form-field.tsx
+++ b/web/src/components/pipeline/pipeline-form-field/pipeline-form-field.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useMemo } from 'react';
 import { PipelineData, Step } from 'api/typings';
 import { noop } from 'lodash';

--- a/web/src/components/pipeline/pipeline-text-area/pipeline-text-area.tsx
+++ b/web/src/components/pipeline/pipeline-text-area/pipeline-text-area.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import { TextArea, Text } from '@epam/loveship';
 import React, { FC, useState } from 'react';
 import { ReactComponent as EditIcon } from '@epam/assets/icons/common/content-edit-12.svg';

--- a/web/src/components/pipeline/pipeline-utils/create-flow-elements.ts
+++ b/web/src/components/pipeline/pipeline-utils/create-flow-elements.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import { PipelineData, Step } from 'api/typings';
 import { FlowElement, Node, Position } from 'react-flow-renderer';
 

--- a/web/src/components/pipeline/pipelines-sidebar/pipelines-sidebar.tsx
+++ b/web/src/components/pipeline/pipelines-sidebar/pipelines-sidebar.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useState } from 'react';
 import { DocumentsSidebarConnector, RenderCreateBtn } from 'connectors/documents-sidebar-connector';
 import { usePipelines } from 'api/hooks/pipelines';

--- a/web/src/components/preprocessor-picker/preprocessor-picker.tsx
+++ b/web/src/components/preprocessor-picker/preprocessor-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Panel, PickerInput } from '@epam/loveship';
 import { LazyDataSource } from '@epam/uui';

--- a/web/src/components/reports/retrieve-reports-list.tsx
+++ b/web/src/components/reports/retrieve-reports-list.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Report, User } from 'api/typings';
 import { ILens } from '@epam/uui';

--- a/web/src/components/split-annotator-info/split-annotator-info.tsx
+++ b/web/src/components/split-annotator-info/split-annotator-info.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import styles from './split-annotator-info.module.scss';
 

--- a/web/src/components/task/create-task-form/create-task-form.tsx
+++ b/web/src/components/task/create-task-form/create-task-form.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, ReactNode, useCallback, useRef, useState } from 'react';
 import DatePicker from 'react-datepicker';
 import {

--- a/web/src/components/task/task-document-pages/task-document-pages.tsx
+++ b/web/src/components/task/task-document-pages/task-document-pages.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 import DocumentPages from 'shared/components/document-pages/document-pages';

--- a/web/src/components/task/task-modal/task-validation-modal.tsx
+++ b/web/src/components/task/task-modal/task-validation-modal.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC, ReactNode, useState } from 'react';
 
 import {

--- a/web/src/components/task/task-sidebar-data/task-sidebar-data.tsx
+++ b/web/src/components/task/task-sidebar-data/task-sidebar-data.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC, Fragment, useRef, useState } from 'react';
 import { CategoryDataAttributeWithValue } from 'api/typings';
 import { TaxonomiesTree } from 'components/taxonomies/taxonomies-tree';

--- a/web/src/components/task/task-sidebar-flow/__tests__/annotation-list.test.tsx
+++ b/web/src/components/task/task-sidebar-flow/__tests__/annotation-list.test.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { render } from 'shared/helpers/testUtils/render';
 import { AnnotationBoundType } from 'shared';

--- a/web/src/components/task/task-sidebar-flow/__tests__/annotation.test.tsx
+++ b/web/src/components/task/task-sidebar-flow/__tests__/annotation.test.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { render } from 'shared/helpers/testUtils/render';
 import { AnnotationRow } from '../annotationRow';

--- a/web/src/components/task/task-sidebar-flow/annotation-list.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotation-list.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnnotationRow } from './annotationRow';
 import { Annotation, Maybe } from 'shared';

--- a/web/src/components/task/task-sidebar-flow/annotationRow.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotationRow.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC, useCallback } from 'react';
 import { ANNOTATION_FLOW_ITEM_ID_PREFIX } from 'shared/constants/annotations';
 import { ANNOTATION_PATH_SEPARATOR } from './constants';

--- a/web/src/components/task/task-sidebar-flow/label-row.tsx
+++ b/web/src/components/task/task-sidebar-flow/label-row.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { FlexRow, IconButton, Text } from '@epam/loveship';
 import { Label } from 'api/typings';

--- a/web/src/components/task/task-sidebar-flow/links/index.tsx
+++ b/web/src/components/task/task-sidebar-flow/links/index.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Dropdown, IconButton, Panel } from '@epam/loveship';
 import { Annotation } from 'shared';

--- a/web/src/components/task/task-sidebar-flow/links/link-row.tsx
+++ b/web/src/components/task/task-sidebar-flow/links/link-row.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { FlexRow, IconContainer, Text } from '@epam/loveship';
 import { Annotation } from 'shared';

--- a/web/src/components/task/task-sidebar-flow/task-sidebar-flow.tsx
+++ b/web/src/components/task/task-sidebar-flow/task-sidebar-flow.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 import { AnnotationList } from './annotation-list';

--- a/web/src/components/task/task-sidebar-labels/task-sidebar-labels.tsx
+++ b/web/src/components/task/task-sidebar-labels/task-sidebar-labels.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks */
 import React, { FC, useMemo, useRef } from 'react';
 import { noop } from 'lodash';
 

--- a/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React from 'react';
 import {
     ModalBlocker,

--- a/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/confirm-modal/confirm-modal.tsx
@@ -21,7 +21,9 @@ export const ConfirmModal = (modalProps: IModal<string>) => (
                 <ModalHeader title="Attention" onClose={() => modalProps.abort()} />
                 <ScrollBars hasTopShadow hasBottomShadow>
                     <FlexRow padding="24">
-                        <Text size="36">Are you sure you want to stop annotating this document?</Text>
+                        <Text size="36">
+                            Are you sure you want to stop annotating this document?
+                        </Text>
                     </FlexRow>
                 </ScrollBars>
                 <ModalFooter>

--- a/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
+++ b/web/src/components/task/task-sidebar/finish-button/finish-button.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, useState } from 'react';
 import { useArrayDataSource } from '@epam/uui';
 import { PickerInput, Button, ControlGroup, Tooltip } from '@epam/loveship';

--- a/web/src/components/task/task-sidebar/image-tools-params/image-tools-params.tsx
+++ b/web/src/components/task/task-sidebar/image-tools-params/image-tools-params.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react';
 import { ReactComponent as infoIcon } from '@epam/assets/icons/common/notification-info-outline-18.svg';
 import {

--- a/web/src/components/task/task-sidebar/image-tools/image-tools.tsx
+++ b/web/src/components/task/task-sidebar/image-tools/image-tools.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { AnnotationImageToolType } from '../../../../shared';
 import React from 'react';
 import { FlexRow, IconButton, Tooltip } from '@epam/loveship';

--- a/web/src/components/task/task-sidebar/task-sidebar-labels-links/task-sidebar-labels-links.tsx
+++ b/web/src/components/task/task-sidebar/task-sidebar-labels-links/task-sidebar-labels-links.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { DocumentLinkWithName } from 'api/hooks/annotations';
 import { useCategoriesByJob } from 'api/hooks/categories';

--- a/web/src/components/task/task-sidebar/task-sidebar-links/task-sidebar-links.tsx
+++ b/web/src/components/task/task-sidebar/task-sidebar-links/task-sidebar-links.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { Accordion, Spinner } from '@epam/loveship';
 import { DocumentLinkWithName } from 'api/hooks/annotations';
 import { Category, FileDocument } from 'api/typings';

--- a/web/src/components/task/task-sidebar/task-sidebar.tsx
+++ b/web/src/components/task/task-sidebar/task-sidebar.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { FC, ReactElement, useEffect, useMemo, useState } from 'react';
 import {
     Button,

--- a/web/src/components/taxonomies/taxonomies-tree.tsx
+++ b/web/src/components/taxonomies/taxonomies-tree.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useCallback, useMemo } from 'react';
 import { Spinner } from '@epam/loveship';
 import { TaxonomyNode, TTreeNode } from 'api/typings';

--- a/web/src/components/taxonomies/use-taxonomies-tree.tsx
+++ b/web/src/components/taxonomies/use-taxonomies-tree.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { taxonsFetcher } from 'api/hooks/taxons';
 import {
     Operators,

--- a/web/src/components/upload-files-control/upload-files-control.tsx
+++ b/web/src/components/upload-files-control/upload-files-control.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useCallback } from 'react';
 import { Blocker } from '@epam/loveship';
 

--- a/web/src/components/upload-wizard/model-info/model-info.tsx
+++ b/web/src/components/upload-wizard/model-info/model-info.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { useModelById } from '../../../api/hooks/models';
 import styles from '../preprocessor/upload-wizard-preprocessor.module.scss';

--- a/web/src/components/upload-wizard/preprocessor/upload-wizard-preprocessor.tsx
+++ b/web/src/components/upload-wizard/preprocessor/upload-wizard-preprocessor.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useState } from 'react';
 import { FlexRow, IconButton, PickerInput, RadioInput, Text, Tooltip } from '@epam/loveship';
 import { ReactComponent as InfoIcon } from '@epam/assets/icons/common/notification-info-outline-18.svg';

--- a/web/src/connectors/SH-dashboard-table-connector/SH-dashboard-table-connector.tsx
+++ b/web/src/connectors/SH-dashboard-table-connector/SH-dashboard-table-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, useContext, useEffect, useMemo } from 'react';
 import { DataTable, Panel, Text } from '@epam/loveship';
 import { TableWrapper, usePageTable } from 'shared';

--- a/web/src/connectors/SH-dashboard-table-connector/sh-columns.tsx
+++ b/web/src/connectors/SH-dashboard-table-connector/sh-columns.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { useMemo } from 'react';
 import { Task, TaskStatus } from '../../api/typings/tasks';
 import { FlexRow, Text } from '@epam/loveship';

--- a/web/src/connectors/add-basement-connector/add-basement-connector.tsx
+++ b/web/src/connectors/add-basement-connector/add-basement-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, useCallback, useEffect } from 'react';
 import { Form, INotification, IFormApi } from '@epam/uui';
 import { ErrorNotification, Text } from '@epam/loveship';

--- a/web/src/connectors/add-dataset-connector/add-dataset-connector.tsx
+++ b/web/src/connectors/add-dataset-connector/add-dataset-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 
 import { DatasetAddForm, DatasetValues } from 'components/dataset/dataset-add-form';

--- a/web/src/connectors/basements-table-connector/basements-columns.tsx
+++ b/web/src/connectors/basements-table-connector/basements-columns.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { ReactNode } from 'react';
 import {
     Dropdown,

--- a/web/src/connectors/basements-table-connector/basements-table-connector.tsx
+++ b/web/src/connectors/basements-table-connector/basements-table-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import { Button, DataTable, Panel } from '@epam/loveship';
 import React, { FC, useEffect } from 'react';
 import {

--- a/web/src/connectors/categories-modal-connector/categories-modal-connector.tsx
+++ b/web/src/connectors/categories-modal-connector/categories-modal-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { useArrayDataSource } from '@epam/uui';
 import {

--- a/web/src/connectors/categories-table-connector/categories-column.tsx
+++ b/web/src/connectors/categories-table-connector/categories-column.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import { Category } from '../../api/typings';
 import { Text } from '@epam/loveship';
 import React from 'react';

--- a/web/src/connectors/categories-table-connector/categories-table-connector.tsx
+++ b/web/src/connectors/categories-table-connector/categories-table-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useEffect } from 'react';
 import { Button, DataTable, Panel } from '@epam/loveship';
 

--- a/web/src/connectors/document-page-connector/document-page-connector.tsx
+++ b/web/src/connectors/document-page-connector/document-page-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react';
 import { DocumentPage } from '../../pages';
 import { useDocuments } from '../../api/hooks/documents';

--- a/web/src/connectors/documents-card-connector/documents-card-connector.tsx
+++ b/web/src/connectors/documents-card-connector/documents-card-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps, eqeqeq */
 import React, { FC, useEffect, useState, useContext } from 'react';
 import { TableWrapper, usePageTable } from 'shared';
 import { DocumentCardViewItem } from '../../components/documents/document-card-view-item/document-card-view-item';

--- a/web/src/connectors/documents-page-control-connector/documents-filter-card-icon.tsx
+++ b/web/src/connectors/documents-page-control-connector/documents-filter-card-icon.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DocumentView } from 'api/typings';
 import React, { FC } from 'react';
 

--- a/web/src/connectors/documents-page-control-connector/documents-filter-list-icon.tsx
+++ b/web/src/connectors/documents-page-control-connector/documents-filter-list-icon.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DocumentView } from 'api/typings';
 import React, { FC } from 'react';
 

--- a/web/src/connectors/documents-page-control-connector/documents-page-control-connector.tsx
+++ b/web/src/connectors/documents-page-control-connector/documents-page-control-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { useCallback, useState, useContext } from 'react';
 import {
     Button,

--- a/web/src/connectors/documents-search-connector/documents-search-connector.tsx
+++ b/web/src/connectors/documents-search-connector/documents-search-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useState, useContext } from 'react';
 import styles from './documents-search-connector.module.scss';
 import { Checkbox, SearchInput, LinkButton } from '@epam/loveship';

--- a/web/src/connectors/documents-sidebar-connector/documents-sidebar-connector.tsx
+++ b/web/src/connectors/documents-sidebar-connector/documents-sidebar-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react';
 import { FlexRow, FlexSpacer, LinkButton, SearchInput, VirtualList } from '@epam/loveship';
 import noop from 'lodash/noop';

--- a/web/src/connectors/documents-table-connector/documents-columns.tsx
+++ b/web/src/connectors/documents-table-connector/documents-columns.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import { DataColumnProps } from '@epam/uui';
 import { FileDocument } from 'api/typings';
 import { Text } from '@epam/loveship';

--- a/web/src/connectors/documents-table-connector/documents-table-connector.tsx
+++ b/web/src/connectors/documents-table-connector/documents-table-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { useEffect, useMemo, useRef, useState, useContext } from 'react';
 import styles from './documents-table-connector.module.scss';
 import {

--- a/web/src/connectors/edit-job-connector/edit-job-connector.tsx
+++ b/web/src/connectors/edit-job-connector/edit-job-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, ReactElement, useCallback, useContext, useMemo } from 'react';
 import EditJobSettings from 'components/job/edit-job-settings/edit-job-settings';
 import { usePipelines } from 'api/hooks/pipelines';
@@ -64,8 +66,8 @@ export type JobValues = {
 };
 
 const validationTypeTitle = {
-    'extensive_coverage': 'Extensive Coverage',
-    'hierarchical': 'Hierarchical Validation'
+    extensive_coverage: 'Extensive Coverage',
+    hierarchical: 'Hierarchical Validation'
 };
 const EditJobConnector: FC<EditJobConnectorProps> = ({
     renderWizardButtons,

--- a/web/src/connectors/edit-job-connector/edit-job-connector.tsx
+++ b/web/src/connectors/edit-job-connector/edit-job-connector.tsx
@@ -64,8 +64,8 @@ export type JobValues = {
 };
 
 const validationTypeTitle = {
-    ['extensive_coverage']: 'Extensive Coverage',
-    ['hierarchical']: 'Hierarchical Validation'
+    'extensive_coverage': 'Extensive Coverage',
+    'hierarchical': 'Hierarchical Validation'
 };
 const EditJobConnector: FC<EditJobConnectorProps> = ({
     renderWizardButtons,

--- a/web/src/connectors/form-model-connector/form-model-connector.tsx
+++ b/web/src/connectors/form-model-connector/form-model-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps, react-hooks/rules-of-hooks */
 import React, { FC, useCallback, useState } from 'react';
 import AddModelSettings from 'components/model/add-model-settings/add-model-settings';
 import AddModelData from 'components/model/add-model-data/add-model-data';

--- a/web/src/connectors/job-detail-view-connector/job-detail-view-connector.tsx
+++ b/web/src/connectors/job-detail-view-connector/job-detail-view-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useJobById } from 'api/hooks/jobs';
 import { FileDocument, User } from 'api/typings';

--- a/web/src/connectors/job-detail-view-connector/job-files-columns.tsx
+++ b/web/src/connectors/job-detail-view-connector/job-files-columns.tsx
@@ -1,7 +1,10 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import { FileDocument } from '../../api/typings';
 import { Text } from '@epam/loveship';
 import React from 'react';
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default [
     {
         key: 'original_name',

--- a/web/src/connectors/job-detail-view-connector/job-tasks-column.tsx
+++ b/web/src/connectors/job-detail-view-connector/job-tasks-column.tsx
@@ -1,7 +1,10 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import { ApiTask } from '../../api/typings/tasks';
 import { FlexRow, Text } from '@epam/loveship';
 import React from 'react';
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default [
     {
         key: 'name',

--- a/web/src/connectors/job-detail-view-sidebar-connector/job-detail-view-sidebar-connector.tsx
+++ b/web/src/connectors/job-detail-view-sidebar-connector/job-detail-view-sidebar-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useJobById } from '../../api/hooks/jobs';
 import { useUserByForJob } from '../../api/hooks/users';

--- a/web/src/connectors/jobs-table-connector/jobs-columns.tsx
+++ b/web/src/connectors/jobs-table-connector/jobs-columns.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React from 'react';
 import { Job } from 'api/typings/jobs';
 import { Status } from 'shared/components/status';

--- a/web/src/connectors/jobs-table-connector/jobs-table-connector.tsx
+++ b/web/src/connectors/jobs-table-connector/jobs-table-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import { Button, DataTable, Panel } from '@epam/loveship';
 import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { useLazyDataSource } from '@epam/uui';

--- a/web/src/connectors/login-connector/login-connector.tsx
+++ b/web/src/connectors/login-connector/login-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable no-restricted-globals, react-hooks/exhaustive-deps */
 import React, { useEffect } from 'react';
 
 import {

--- a/web/src/connectors/model-detailed-view-connector/model-detailed-view-connector.tsx
+++ b/web/src/connectors/model-detailed-view-connector/model-detailed-view-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useMemo, useState } from 'react';
 import { useModelById } from '../../api/hooks/models';
 import { ModelInfo } from '../../components/model/model-info/model-info';

--- a/web/src/connectors/models-table-connector/models-columns.tsx
+++ b/web/src/connectors/models-table-connector/models-columns.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, @typescript-eslint/no-unused-vars */
 import {
     DropdownMenuBody,
     DropdownMenuButton,

--- a/web/src/connectors/models-table-connector/models-table-connector.tsx
+++ b/web/src/connectors/models-table-connector/models-table-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import { Button, DataTable, Panel } from '@epam/loveship';
 import React, { FC, useEffect, useMemo } from 'react';
 import { Model, Operators, SortingDirection, TableFilters } from 'api/typings';

--- a/web/src/connectors/pipeline-connector/pipeline-connector.tsx
+++ b/web/src/connectors/pipeline-connector/pipeline-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { usePipelineByName } from 'api/hooks/pipelines';
 import PipelineComponent from 'components/pipeline/pipeline-component/pipeline-component';

--- a/web/src/connectors/reports-connector/reports-connector.tsx
+++ b/web/src/connectors/reports-connector/reports-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps, @typescript-eslint/no-redeclare */
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useUsers } from 'api/hooks/users';
 import { Report, SortingDirection } from 'api/typings';
@@ -67,7 +69,8 @@ export const ReportsConnector: FC<{}> = () => {
             const values = users.data?.data;
 
             const formInvalid = isFormInvalid(lens);
-            /* eslint-disable jsx-a11y/anchor-has-content */
+            // temporary_disabled_rules
+            /* eslint-disable jsx-a11y/anchor-has-content, react-hooks/rules-of-hooks */
             return (
                 <>
                     <RetrieveReportsList lens={lens} users={values} />

--- a/web/src/connectors/step-form-connector/step-form-connector.tsx
+++ b/web/src/connectors/step-form-connector/step-form-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Form } from '@epam/uui';
 import { useModels, useBasements } from 'api/hooks/models';
 import { SortingDirection, Model, Operators, PipelineTypes } from 'api/typings';

--- a/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
+++ b/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, eqeqeq, @typescript-eslint/no-unused-expressions */
 import React, {
     createContext,
     MutableRefObject,

--- a/web/src/connectors/task-annotator-connector/use-document-links.ts
+++ b/web/src/connectors/task-annotator-connector/use-document-links.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { DocumentLink, DocumentLinkWithName } from 'api/hooks/annotations';
 import { useDocuments } from 'api/hooks/documents';
 import { FileDocument, Operators } from 'api/typings';

--- a/web/src/connectors/task-annotator-connector/use-split-validation.ts
+++ b/web/src/connectors/task-annotator-connector/use-split-validation.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { AnnotationsByUser, useLatestAnnotationsByUser } from 'api/hooks/annotations';
 import { Category, Link, Taxon } from 'api/typings';
 import { JobStatus, Job } from 'api/typings/jobs';

--- a/web/src/connectors/task-annotator-connector/use-task-users.ts
+++ b/web/src/connectors/task-annotator-connector/use-task-users.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { FilterWithDocumentExtraOption, Operators, TUserShort, User } from '../../api/typings';
 import { useJobById } from '../../api/hooks/jobs';
 import { useEffect, useMemo, useRef, useState } from 'react';

--- a/web/src/connectors/task-annotator-connector/use-validation.tsx
+++ b/web/src/connectors/task-annotator-connector/use-validation.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks, @typescript-eslint/no-unused-expressions */
 import React, {
     Dispatch,
     MutableRefObject,

--- a/web/src/connectors/tasks-table-connector/constants.tsx
+++ b/web/src/connectors/tasks-table-connector/constants.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React from 'react';
 import { FlexRow, Text } from '@epam/loveship';
 import { DataColumnProps } from '@epam/uui';

--- a/web/src/connectors/tasks-table-connector/tasks-table-connector.tsx
+++ b/web/src/connectors/tasks-table-connector/tasks-table-connector.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useContext, useEffect, useMemo } from 'react';
 import { DataTable, Panel } from '@epam/loveship';
 import { useArrayDataSource } from '@epam/uui';

--- a/web/src/connectors/tasks/create-task/create-task.tsx
+++ b/web/src/connectors/tasks/create-task/create-task.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, useCallback } from 'react';
 
 import { IModal } from '@epam/uui';

--- a/web/src/icons/sort-icon/sort-icon.tsx
+++ b/web/src/icons/sort-icon/sort-icon.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { ReactComponent as SortAsc } from '@epam/assets/icons/common/table-sort_asc-18.svg';
 import { ReactComponent as SortDesc } from '@epam/assets/icons/common/table-sort_desc-18.svg';

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router } from 'react-router-dom';

--- a/web/src/pages/SH-Dashboard/sh-dashboard.tsx
+++ b/web/src/pages/SH-Dashboard/sh-dashboard.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { useCallback, useEffect, useState } from 'react';
 import { Button, FlexRow } from '@epam/loveship';
 import { Switch, Route, useRouteMatch, Redirect, useHistory } from 'react-router';

--- a/web/src/pages/basements/basements-page.tsx
+++ b/web/src/pages/basements/basements-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { useCallback, useState } from 'react';
 import { Switch, Route, useRouteMatch, Redirect, useHistory } from 'react-router-dom';
 import { svc } from '../../services';

--- a/web/src/pages/document/document-page.tsx
+++ b/web/src/pages/document/document-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useCallback, useState } from 'react';
 
 import {

--- a/web/src/pages/documents/documents-page.tsx
+++ b/web/src/pages/documents/documents-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useCallback, useState } from 'react';
 import { Sidebar } from 'shared';
 import {

--- a/web/src/pages/job/job-page.tsx
+++ b/web/src/pages/job/job-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { JobConnector } from 'connectors/job-detail-view-connector/job-detail-view-connector';

--- a/web/src/pages/jobs/edit-job-page.tsx
+++ b/web/src/pages/jobs/edit-job-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useEffect, useState } from 'react';
 
 import { useHistory, useParams } from 'react-router-dom';

--- a/web/src/pages/login/login-page.tsx
+++ b/web/src/pages/login/login-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React from 'react';
 import { Panel, Text } from '@epam/loveship';
 import { LoginConnector } from 'connectors/login-connector';

--- a/web/src/pages/model/model-page.tsx
+++ b/web/src/pages/model/model-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { ModelDetailedViewConnector } from '../../connectors/model-detailed-view-connector/model-detailed-view-connector';

--- a/web/src/pages/models/models-page.tsx
+++ b/web/src/pages/models/models-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { useCallback } from 'react';
 import { Switch, Route, useRouteMatch, Redirect, useHistory } from 'react-router-dom';
 import { ModelsTableConnector } from 'connectors/models-table-connector';

--- a/web/src/pages/pipelines/pipelines-page.tsx
+++ b/web/src/pages/pipelines/pipelines-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useCallback } from 'react';
 import { Switch, Route, useRouteMatch, Redirect, useHistory } from 'react-router-dom';
 import AddPipelineForm from 'components/pipeline/add-pipeline-form';

--- a/web/src/pages/task/picker-grid-type/picker-grid-type.tsx
+++ b/web/src/pages/task/picker-grid-type/picker-grid-type.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { DataPickerRow, FlexRow, PickerInput, Text } from '@epam/loveship';
 import { DataRowProps, useArrayDataSource } from '@epam/uui';

--- a/web/src/pages/task/task-page.tsx
+++ b/web/src/pages/task/task-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps, react-hooks/rules-of-hooks */
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import TaskDocumentPages from 'components/task/task-document-pages/task-document-pages';
 import TaskSidebar from 'components/task/task-sidebar/task-sidebar';

--- a/web/src/pages/tasks/dashboard-page.tsx
+++ b/web/src/pages/tasks/dashboard-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { TasksTableConnector } from 'connectors/tasks-table-connector/tasks-table-connector';
 import styles from './dashboard-page.module.scss';

--- a/web/src/pages/upload-document-wizard/upload-document-wizard-page.tsx
+++ b/web/src/pages/upload-document-wizard/upload-document-wizard-page.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { useCallback, useContext, useState } from 'react';
 import { useHistory } from 'react-router';
 import Wizard, {

--- a/web/src/setupTests.tsx
+++ b/web/src/setupTests.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)

--- a/web/src/shared/components/annotator/annotator.tsx
+++ b/web/src/shared/components/annotator/annotator.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, {
     CSSProperties,
     FC,

--- a/web/src/shared/components/annotator/components/box-annotation/resizer.tsx
+++ b/web/src/shared/components/annotator/components/box-annotation/resizer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import styles from './box-annotation.module.scss';
 import { ANNOTATION_RESIZER_CLASS } from './box-annotation';

--- a/web/src/shared/components/annotator/components/box-selection/box-selection.tsx
+++ b/web/src/shared/components/annotator/components/box-selection/box-selection.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { CSSProperties, FC } from 'react';
 import { Rect } from '../../typings';
 

--- a/web/src/shared/components/annotator/components/image-annotation/image-annotation.tsx
+++ b/web/src/shared/components/annotator/components/image-annotation/image-annotation.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { RefObject, useEffect } from 'react';
 import { Annotation, AnnotationImageTool, Bound } from '../../typings';
 import paper from 'paper';

--- a/web/src/shared/components/annotator/components/link-annotation/link-annotation.tsx
+++ b/web/src/shared/components/annotator/components/link-annotation/link-annotation.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, eqeqeq, react-hooks/exhaustive-deps */
 import React, { CSSProperties, useMemo } from 'react';
 import { getStyledLinkByBounds, LinkAnnotationProps } from './helpers';
 import { ReactComponent as closeIcon } from '@epam/assets/icons/common/navigation-close-12.svg';

--- a/web/src/shared/components/annotator/components/page-token/page-token.tsx
+++ b/web/src/shared/components/annotator/components/page-token/page-token.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import type { PageToken, TokenStyle } from '../../typings';
 import styles from './page-token.module.scss';

--- a/web/src/shared/components/annotator/components/table-annotation/cell-selection-layer/cell-selection-layer.tsx
+++ b/web/src/shared/components/annotator/components/table-annotation/cell-selection-layer/cell-selection-layer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { Bound } from '../../../typings';
 

--- a/web/src/shared/components/annotator/components/table-annotation/helpers.tsx
+++ b/web/src/shared/components/annotator/components/table-annotation/helpers.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import {
     Annotation,
     Bound,

--- a/web/src/shared/components/annotator/components/table-annotation/table-annotation.tsx
+++ b/web/src/shared/components/annotator/components/table-annotation/table-annotation.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import noop from 'lodash/noop';
 import React, { useEffect, useRef, useState } from 'react';
 import {

--- a/web/src/shared/components/annotator/components/text-annotation/text-annotation.tsx
+++ b/web/src/shared/components/annotator/components/text-annotation/text-annotation.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, eqeqeq */
 import React, { Fragment, useMemo } from 'react';
 import noop from 'lodash/noop';
 

--- a/web/src/shared/components/annotator/context/table-annotator-context.tsx
+++ b/web/src/shared/components/annotator/context/table-annotator-context.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { createContext, FC, useMemo, useContext, useState } from 'react';
 
 type TableContextValue = {

--- a/web/src/shared/components/annotator/hooks/use-active-tokens-calculation.tsx
+++ b/web/src/shared/components/annotator/hooks/use-active-tokens-calculation.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useMemo } from 'react';
 import {
     Point,

--- a/web/src/shared/components/annotator/hooks/use-annotations-click.ts
+++ b/web/src/shared/components/annotator/hooks/use-annotations-click.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable eqeqeq, react-hooks/exhaustive-deps */
 import React, { RefObject, useCallback } from 'react';
 import { AnnotationImageToolType, AnnotationLinksBoundType } from 'shared';
 import { Annotation, AnnotationBoundType, Point } from '../typings';

--- a/web/src/shared/components/annotator/hooks/use-cell-selection.ts
+++ b/web/src/shared/components/annotator/hooks/use-cell-selection.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import { RefObject } from 'react';
 import { Annotation, Point, Bound, TableGutter, GutterType, TableGutterMap, Maybe } from '..';
 import { useMouseEvents } from './use-mouse-events';

--- a/web/src/shared/components/annotator/hooks/use-gutter-click.ts
+++ b/web/src/shared/components/annotator/hooks/use-gutter-click.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { RefObject, useCallback } from 'react';
 import { Annotation, Maybe, Point, TableGutter, TableGutterMap } from '../typings';
 import { getRefOffset } from '../utils/get-ref-offset';

--- a/web/src/shared/components/annotator/hooks/use-mouse-events.ts
+++ b/web/src/shared/components/annotator/hooks/use-mouse-events.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useRef, useEffect } from 'react';
 import noop from 'lodash/noop';
 import { Point } from '..';

--- a/web/src/shared/components/annotator/hooks/use-submit-annotation.ts
+++ b/web/src/shared/components/annotator/hooks/use-submit-annotation.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useCallback } from 'react';
 import {
     Point,

--- a/web/src/shared/components/annotator/layers/annotations-layer/annotations-default-renderer.tsx
+++ b/web/src/shared/components/annotator/layers/annotations-layer/annotations-default-renderer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { BoxAnnotation } from '../../components/box-annotation';
 import { AnnotationRenderer, PageToken } from '../../typings';

--- a/web/src/shared/components/annotator/layers/annotations-layer/annotations-editable-renderer.tsx
+++ b/web/src/shared/components/annotator/layers/annotations-layer/annotations-editable-renderer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { RefObject } from 'react';
 import { BoxAnnotation } from '../../components/box-annotation';
 import { EditableAnnotationRenderer, PageToken } from '../../typings';

--- a/web/src/shared/components/annotator/layers/selection-layer/selection-layer.tsx
+++ b/web/src/shared/components/annotator/layers/selection-layer/selection-layer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 import React, { CSSProperties, FC, useMemo } from 'react';
 import { Point, AnnotationBoundType, PageToken, AnnotationImageToolType } from '../../typings';
 import { BoxSelection } from '../../components/box-selection/box-selection';

--- a/web/src/shared/components/annotator/layers/tokens-layer/tokens-layer.tsx
+++ b/web/src/shared/components/annotator/layers/tokens-layer/tokens-layer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { CSSProperties, FC, useMemo } from 'react';
 import { Token } from '../../components/page-token';
 import { PageToken } from '../../typings';

--- a/web/src/shared/components/annotator/links-layer.tsx
+++ b/web/src/shared/components/annotator/links-layer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Annotation } from './typings';
 import { Link } from '../../../api/typings';

--- a/web/src/shared/components/annotator/utils/get-points-for-link.ts
+++ b/web/src/shared/components/annotator/utils/get-points-for-link.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable eqeqeq */
 import { Category, Link } from 'api/typings';
 import {
     Annotation,

--- a/web/src/shared/components/annotator/utils/use-annotation-links.ts
+++ b/web/src/shared/components/annotator/utils/use-annotation-links.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable eqeqeq, react-hooks/exhaustive-deps */
 import { Category } from 'api/typings';
 import { useEffect, useRef } from 'react';
 import {

--- a/web/src/shared/components/badger-tree/badger-tree.tsx
+++ b/web/src/shared/components/badger-tree/badger-tree.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, ReactElement, useMemo } from 'react';
 import { NoData } from 'shared/no-data';
 import { TTreeNode } from 'api/typings';

--- a/web/src/shared/components/breadcrumb/breadcrumb-navigation.test.tsx
+++ b/web/src/shared/components/breadcrumb/breadcrumb-navigation.test.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { render } from '@testing-library/react';
 import { BreadcrumbNavigation } from './breadcrumb-navigation';

--- a/web/src/shared/components/breadcrumb/breadcrumb-navigation.tsx
+++ b/web/src/shared/components/breadcrumb/breadcrumb-navigation.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { FlexRow, IconContainer, Text } from '@epam/loveship';
 import { ReactComponent as navigation } from '@epam/assets/icons/common/navigation-chevron-right-12.svg';

--- a/web/src/shared/components/categories-picker/categories-picker.tsx
+++ b/web/src/shared/components/categories-picker/categories-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { FC, useCallback, useRef } from 'react';
 import { JobValues } from '../../../connectors/edit-job-connector/edit-job-connector';
 import { Category, PagingCache, PagingFetcher, SortingDirection } from '../../../api/typings';

--- a/web/src/shared/components/document-pages/components/ResizableSyncedContainer/index.tsx
+++ b/web/src/shared/components/document-pages/components/ResizableSyncedContainer/index.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useRef, useState } from 'react';
 import DraggableResizer from '../draggable-resizer/draggable-resizer';
 import { useTaskAnnotatorContext } from '../../../../../connectors/task-annotator-connector/task-annotator-context';

--- a/web/src/shared/components/document-pages/components/document-pdf/index.tsx
+++ b/web/src/shared/components/document-pages/components/document-pdf/index.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import React, { CSSProperties, FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';

--- a/web/src/shared/components/document-pages/components/draggable-resizer/draggable-resizer.tsx
+++ b/web/src/shared/components/document-pages/components/draggable-resizer/draggable-resizer.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import { cx } from '@epam/uui-core';
 import React, { DragEvent, useState } from 'react';
 import { GridVariants } from 'shared/constants/task';

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { Fragment, useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 import { Document, Page, pdfjs, PDFPageProxy } from 'react-pdf';

--- a/web/src/shared/components/filters/column-picker.tsx
+++ b/web/src/shared/components/filters/column-picker.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { ReactNode, useCallback, useMemo } from 'react';
 import { ColumnPickerFilter, RangeDatePicker } from '@epam/loveship';
 import { IDataSource, ILens } from '@epam/uui';

--- a/web/src/shared/components/image/image.tsx
+++ b/web/src/shared/components/image/image.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import React from 'react';
 import { useAssetById } from '../../../api/hooks/assets';
 import { useTaskAnnotatorContext } from '../../../connectors/task-annotator-connector/task-annotator-context';

--- a/web/src/shared/components/info-icon/info-icon.tsx
+++ b/web/src/shared/components/info-icon/info-icon.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, ReactElement } from 'react';
 import { ReactComponent as Icon } from '@epam/assets/icons/common/notification-info-outline-18.svg';
 import { Tooltip } from '@epam/loveship';

--- a/web/src/shared/components/job/job-sidebar-header.tsx
+++ b/web/src/shared/components/job/job-sidebar-header.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 import React, { useEffect, useMemo } from 'react';
 import styles from './job-sidebar-header.module.scss';
 import { Job, JobStatus, JobType } from '../../../api/typings/jobs';

--- a/web/src/shared/components/job/job-table-component.tsx
+++ b/web/src/shared/components/job/job-table-component.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { DataTable } from '@epam/loveship';
 import { TableWrapper } from '../table-wrapper';

--- a/web/src/shared/components/labels/labels.tsx
+++ b/web/src/shared/components/labels/labels.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useCallback } from 'react';
 import { Dropdown, Button, DropdownContainer } from '@epam/loveship';
 import { LabelRow } from '../../../components/task/task-sidebar-flow/label-row';

--- a/web/src/shared/components/model/model-render-components.tsx
+++ b/web/src/shared/components/model/model-render-components.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { FlexRow, LabeledInput, PickerInput, TextInput } from '@epam/loveship';
 import { ArrayDataSource } from '@epam/uui';

--- a/web/src/shared/components/multi-switch-menu/MultiSwitchMenu.tsx
+++ b/web/src/shared/components/multi-switch-menu/MultiSwitchMenu.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { MultiSwitch } from '@epam/loveship';
 import { useHistory } from 'react-router-dom';

--- a/web/src/shared/components/notifications/index.tsx
+++ b/web/src/shared/components/notifications/index.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import React, { ReactNode, useMemo } from 'react';
 import {
     Text,

--- a/web/src/shared/components/observed-element/observed-element.tsx
+++ b/web/src/shared/components/observed-element/observed-element.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, FC, useRef, useMemo } from 'react';
 
 const useIntersectionThreshold = (

--- a/web/src/shared/components/paper/paper.tsx
+++ b/web/src/shared/components/paper/paper.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import styles from './paper.module.scss';
 import React, { PropsWithChildren } from 'react';
 

--- a/web/src/shared/components/pending-content/pending-content.tsx
+++ b/web/src/shared/components/pending-content/pending-content.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import { Spinner } from '@epam/loveship';
 import { PropsWithChildren } from 'react';

--- a/web/src/shared/components/progress-bar/progress-bar.tsx
+++ b/web/src/shared/components/progress-bar/progress-bar.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useRef, useEffect } from 'react';
 import './progress-bar.scss';
 

--- a/web/src/shared/components/sidebar/sidebar-button/sidebar-button.tsx
+++ b/web/src/shared/components/sidebar/sidebar-button/sidebar-button.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Button } from '@epam/loveship';
 import { ReactComponent as plusIcon } from '@epam/assets/icons/common/action-add-18.svg';

--- a/web/src/shared/components/sidebar/sidebar.tsx
+++ b/web/src/shared/components/sidebar/sidebar.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useMemo, useState } from 'react';
 import { FlexSpacer, IconButton, FlexRow } from '@epam/loveship';
 import styles from './sidebar.module.scss';

--- a/web/src/shared/components/status/status.tsx
+++ b/web/src/shared/components/status/status.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React, { FC } from 'react';
 import { JobStatus } from 'api/typings/jobs';
 import { Text, Tooltip } from '@epam/loveship';

--- a/web/src/shared/components/table-filters/table-filter-input/table-filter-input.tsx
+++ b/web/src/shared/components/table-filters/table-filter-input/table-filter-input.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useCallback, useState, FC } from 'react';
 import { IEditable } from '@epam/uui';
 import { FlexRow, NumericInput, Panel } from '@epam/loveship';

--- a/web/src/shared/components/table-filters/table-filter-wrapper/table-filter-wrapper.tsx
+++ b/web/src/shared/components/table-filters/table-filter-wrapper/table-filter-wrapper.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC } from 'react';
 import { Button, FlexRow, FlexSpacer, Panel } from '@epam/loveship';
 

--- a/web/src/shared/components/table-wrapper/table-wrapper.tsx
+++ b/web/src/shared/components/table-wrapper/table-wrapper.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useState } from 'react';
 import { FlexCell, FlexRow, FlexSpacer, Paginator, Panel, PickerInput } from '@epam/loveship';
 import { useArrayDataSource } from '@epam/uui';

--- a/web/src/shared/components/taxonomy-pickers/taxonomy-pickers.tsx
+++ b/web/src/shared/components/taxonomy-pickers/taxonomy-pickers.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/rules-of-hooks */
 import { LabeledInput, PickerInput } from '@epam/loveship';
 import { ILens, useArrayDataSource } from '@epam/uui';
 import { Category, Taxonomy } from 'api/typings';

--- a/web/src/shared/components/text/warning-text.tsx
+++ b/web/src/shared/components/text/warning-text.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare */
 import React from 'react';
 import { WarningAlert, Text } from '@epam/loveship';
 import styles from './warning-text.module.scss';

--- a/web/src/shared/components/wizard/dataset-wizard-screen/dataset-wizard-screen.tsx
+++ b/web/src/shared/components/wizard/dataset-wizard-screen/dataset-wizard-screen.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps, eqeqeq */
 import { datasetsFetcher } from 'api/hooks/datasets';
 import { Dataset } from 'api/typings';
 import { RadioInput, TextInput } from '@epam/loveship';

--- a/web/src/shared/components/wizard/wizard-step/wizard-step.tsx
+++ b/web/src/shared/components/wizard/wizard-step/wizard-step.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, ReactNode } from 'react';
 import { ReactComponent as Done } from '@epam/assets/icons/common/notification-check-fill-18.svg';
 import styles from './wizard-step.module.scss';

--- a/web/src/shared/components/wizard/wizard/wizard.tsx
+++ b/web/src/shared/components/wizard/wizard/wizard.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { FC, Fragment } from 'react';
 import WizardStep from '../wizard-step/wizard-step';
 import { Link } from 'react-router-dom';

--- a/web/src/shared/contexts/current-user.tsx
+++ b/web/src/shared/contexts/current-user.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { User } from 'api/typings';
 import { noop, uniq } from 'lodash';

--- a/web/src/shared/contexts/documents-search.tsx
+++ b/web/src/shared/contexts/documents-search.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { noop } from 'lodash';

--- a/web/src/shared/helpers/auth-tools.ts
+++ b/web/src/shared/helpers/auth-tools.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks */
 import { AuthResult, AuthResultRaw, StoredAuthResult } from 'api/typings';
 import Cookies from 'universal-cookie';
 import { useBadgerFetch } from '../../api/hooks/api';

--- a/web/src/shared/helpers/auth-tools.ts
+++ b/web/src/shared/helpers/auth-tools.ts
@@ -96,7 +96,7 @@ export const getAuthHeaders = () => {
     const tenant = getCurrentTenant();
 
     return {
-        ['X-Current-Tenant']: tenant,
+        'X-Current-Tenant': tenant,
         Authorization: 'Bearer ' + details?.accessToken
     };
 };

--- a/web/src/shared/helpers/copy-text.tsx
+++ b/web/src/shared/helpers/copy-text.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-redeclare */
 import React from 'react';
 import { SuccessNotification, Text } from '@epam/loveship';
 import { INotification } from '@epam/uui';

--- a/web/src/shared/helpers/create-paging-cached-loader.ts
+++ b/web/src/shared/helpers/create-paging-cached-loader.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps */
 import { LazyDataSourceApiRequest } from '@epam/uui';
 import { PagingCache, PagingFetcher } from 'api/typings';
 import React, { useCallback } from 'react';

--- a/web/src/shared/helpers/utils.ts
+++ b/web/src/shared/helpers/utils.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, @typescript-eslint/no-redeclare */
 import { DataColumnProps, DataSourceState, useArrayDataSource } from '@epam/uui';
 import { useAsyncSourceTable } from 'shared/hooks/async-source-table';
 import {

--- a/web/src/shared/hooks/async-source-table.ts
+++ b/web/src/shared/hooks/async-source-table.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useAsyncDataSource } from '@epam/uui';
 import { useEffect, useMemo, useRef } from 'react';
 

--- a/web/src/shared/hooks/lazy-loading.ts
+++ b/web/src/shared/hooks/lazy-loading.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useMemo } from 'react';
 
 export const useLazyLoading = (elementRef: any, containerRef: any, onScroll: () => void) => {

--- a/web/src/shared/hooks/model-hook.ts
+++ b/web/src/shared/hooks/model-hook.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useMemo, useState } from 'react';
 import { useArrayDataSource } from '@epam/uui';
 

--- a/web/src/shared/hooks/page-table-hook.ts
+++ b/web/src/shared/hooks/page-table-hook.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { DataSourceState } from '@epam/uui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { pageSizes } from 'shared';

--- a/web/src/shared/hooks/table-columns.ts
+++ b/web/src/shared/hooks/table-columns.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useMemo } from 'react';
 import { DataColumnProps } from '@epam/uui';
 

--- a/web/src/shared/hooks/use-annotations-mapper.ts
+++ b/web/src/shared/hooks/use-annotations-mapper.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps, eqeqeq */
 import { DependencyList, useCallback, useMemo } from 'react';
 import {
     Category,

--- a/web/src/shared/hooks/use-annotations-taxons.ts
+++ b/web/src/shared/hooks/use-annotations-taxons.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useTaxons } from 'api/hooks/taxons';
 import { Operators, PageInfo, SortingDirection, Taxon } from 'api/typings';
 import { useEffect, useMemo, useState } from 'react';

--- a/web/src/shared/hooks/use-entity.ts
+++ b/web/src/shared/hooks/use-entity.ts
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useMemo, useRef } from 'react';
 import { useLazyDataSource } from '@epam/uui';
 import { FilterWithDocumentExtraOption, PagedResponse, PagingCache } from 'api/typings';

--- a/web/src/shared/hooks/use-sync-scroll.tsx
+++ b/web/src/shared/hooks/use-sync-scroll.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable react-hooks/exhaustive-deps, react-hooks/rules-of-hooks */
 import React, { useCallback, useEffect, useRef } from 'react';
 
 interface SyncedContainerProps {

--- a/web/src/shared/no-data/no-data.tsx
+++ b/web/src/shared/no-data/no-data.tsx
@@ -1,3 +1,5 @@
+// temporary_disabled_rules
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
 import styles from './no-data.module.scss';
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5755,13 +5755,6 @@ eslint-plugin-jsx-a11y@^6.3.1, eslint-plugin-jsx-a11y@^6.4.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
-eslint-plugin-prettier@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz"
-  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz"
@@ -6134,11 +6127,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.7"
@@ -10871,13 +10859,6 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
In the scope of this PR, several changes are introduced:
1) `.eslintrc.js` is updated: 
  1.1) `eslint-plugin-prettier` is removed in order to more follow "opionated" rules of "prettier" (this plugin is not generally recommended by prettier tool);
  1.2) `create-react-app`'s plugins are added.
2) `package.json` - some linting/formatting-related scripts are re-organised, `--fix` option for `eslint` is removed to only validate the rules without introducing automatic changes (this can be done seprately), latest ecm script is defined
3) `check:format` script is added to pre-commit in order to validate formatting-related stuff.
4) after updating of the rules for eslint, a lot of issues were found in the codebase ("/web"). All of these issues were **temporary** disabled and should be fixed separately. Disabling was done in most cases automatically (via `eslint-interactive` package).
5) small prettier-related issue is fixed.