### PR TITLE
fix: implements tooltip for in progress validation tasks

### DIFF
--- a/web/src/components/task/task-sidebar/utils.ts
+++ b/web/src/components/task/task-sidebar/utils.ts
@@ -3,9 +3,12 @@ import { FINISHED_TASK_TOOLTIP_TEXT } from './finish-button/utils';
 
 export const getSaveButtonTooltipContent = (
     isSaveButtonDisabled: boolean,
-    taskStatus?: TaskStatus
+    taskStatus?: TaskStatus,
+    isValidation?: boolean
 ) => {
-    if (taskStatus === 'Finished') {
+    if (isValidation && taskStatus === 'In Progress') {
+        return 'Please validate some pages to enable "Save draft" button';
+    } else if (taskStatus === 'Finished') {
         return FINISHED_TASK_TOOLTIP_TEXT;
     } else if (taskStatus === 'Pending') {
         return null;


### PR DESCRIPTION
The goal of this PR is to introduce a specific tooltip for the SaveDraft button for In Progress validation tasks