### PR TITLE
fix: Close Create Task Modal On Save

### DIFF
--- a/web/src/connectors/job-detail-view-connector/job-detail-view-connector.tsx
+++ b/web/src/connectors/job-detail-view-connector/job-detail-view-connector.tsx
@@ -239,6 +239,9 @@ export const JobConnector: React.FC<JobDetailViewProps> = ({
                     jobId={job?.id}
                     fileIds={job?.files || []}
                     annotatorIds={job?.annotators.map(({ id }) => id) || []}
+                    handleCloseModal={() => {
+                        svc.uuiModals.closeAll();
+                    }}
                 />
             ))
             .then(noop)

--- a/web/src/connectors/tasks/create-task/create-task.tsx
+++ b/web/src/connectors/tasks/create-task/create-task.tsx
@@ -27,12 +27,14 @@ interface ICreateNewTaskProps extends IModal<object> {
     annotatorIds: Array<string>;
     fileIds: Array<number>;
     jobId?: number;
+    handleCloseModal: () => void;
 }
 
 export const CreateTask: FC<ICreateNewTaskProps> = ({
     jobId,
     fileIds,
     annotatorIds,
+    handleCloseModal,
     ...modalProps
 }) => {
     const mutation = useCreateNewTaskMutation();
@@ -73,6 +75,7 @@ export const CreateTask: FC<ICreateNewTaskProps> = ({
                         <Text>{`Task is created with id=${response.id}`}</Text>
                     </>
                 );
+                handleCloseModal();
             } catch (error) {
                 const errorObject: ResponseError = JSON.parse((error as Error).message);
                 notifyError(


### PR DESCRIPTION
This PR aims to add logic to close the CreateTask Modal on successful task creation.

The approach consists on passing down a handleCloseModal function as a prop to the CreateTask component