### PR TITLE
feat: reflect currently shown page's order number in "Current page" dropdown when page is scrolled

### DIFF
--- a/web/src/components/task/task-document-pages/task-document-pages.tsx
+++ b/web/src/components/task/task-document-pages/task-document-pages.tsx
@@ -1,22 +1,25 @@
 // temporary_disabled_rules
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react';
+import React, { RefObject } from 'react';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
 import DocumentPages from 'shared/components/document-pages/document-pages';
 import ExternalViewerPopup from 'components/external-viewer-modal/external-viewer-popup';
 import styles from './task-document-pages.module.scss';
 import { GridVariants } from 'shared/constants/task';
+import { TDocumentPDFRef } from 'shared/components/document-pages/components/document-pdf/types';
 
 export interface DocumentPageProps {
     viewMode: boolean;
     additionalScale: number;
     gridVariant?: GridVariants;
+    documentPDFRef: RefObject<TDocumentPDFRef> | null;
 }
 
 const TaskDocumentPages = ({
     viewMode,
     additionalScale,
-    gridVariant = GridVariants.horizontal
+    gridVariant = GridVariants.horizontal,
+    documentPDFRef
 }: DocumentPageProps) => {
     const {
         task,
@@ -54,6 +57,7 @@ const TaskDocumentPages = ({
                 apiPageSize={pageSize}
                 setPageSize={setPageSize}
                 editable={editable}
+                documentPDFRef={documentPDFRef}
             />
         </div>
     );

--- a/web/src/components/task/task-document-pages/task-document-pages.tsx
+++ b/web/src/components/task/task-document-pages/task-document-pages.tsx
@@ -10,14 +10,12 @@ import { GridVariants } from 'shared/constants/task';
 export interface DocumentPageProps {
     viewMode: boolean;
     additionalScale: number;
-    goToPage?: number;
     gridVariant?: GridVariants;
 }
 
 const TaskDocumentPages = ({
     viewMode,
     additionalScale,
-    goToPage,
     gridVariant = GridVariants.horizontal
 }: DocumentPageProps) => {
     const {
@@ -56,7 +54,6 @@ const TaskDocumentPages = ({
                 apiPageSize={pageSize}
                 setPageSize={setPageSize}
                 editable={editable}
-                goToPage={goToPage}
             />
         </div>
     );

--- a/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
+++ b/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
@@ -2,7 +2,9 @@
 /* eslint-disable @typescript-eslint/no-redeclare, react-hooks/rules-of-hooks, react-hooks/exhaustive-deps, eqeqeq, @typescript-eslint/no-unused-expressions */
 import React, {
     createContext,
+    Dispatch,
     MutableRefObject,
+    SetStateAction,
     useCallback,
     useContext,
     useEffect,
@@ -101,6 +103,7 @@ export type TTaskAnnotatorContext = SplitValidationValue &
         pageNumbers: number[];
         currentPage: number;
         currentOrderPageNumber: number;
+        setCurrentOrderPageNumber: Dispatch<SetStateAction<number>>;
         modifiedPages: number[];
         pageSize?: { width: number; height: number };
         setPageSize: (pS: any) => void;
@@ -433,10 +436,10 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
         refetchLatestAnnotations
     } = documentData;
 
-    const onCurrentPageChange = (page: number, orderNumber: number) => {
+    const onCurrentPageChange = useCallback((page: number, orderNumber: number) => {
         setCurrentPage(page);
         setCurrentOrderPageNumber(orderNumber);
-    };
+    }, []);
 
     useEffect(() => {
         if (task || job || revisionId) {
@@ -1147,6 +1150,7 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
             pageNumbers,
             currentPage,
             currentOrderPageNumber,
+            setCurrentOrderPageNumber,
             pageSize,
             setPageSize,
             modifiedPages,
@@ -1227,6 +1231,7 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
         allAnnotations,
         currentPage,
         currentOrderPageNumber,
+        setCurrentOrderPageNumber,
         pageSize,
         tableMode,
         isNeedToSaveTable,

--- a/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
+++ b/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
@@ -100,6 +100,7 @@ export type TTaskAnnotatorContext = SplitValidationValue &
         allAnnotations?: Record<string, Annotation[]>;
         pageNumbers: number[];
         currentPage: number;
+        currentOrderPageNumber: number;
         modifiedPages: number[];
         pageSize?: { width: number; height: number };
         setPageSize: (pS: any) => void;
@@ -140,7 +141,7 @@ export type TTaskAnnotatorContext = SplitValidationValue &
             changes: Partial<Annotation>
         ) => void;
         onLinkDeleted: (pageNum: number, annotationId: string | number, link: Link) => void;
-        onCurrentPageChange: (page: number) => void;
+        onCurrentPageChange: (page: number, orderNumber: number) => void;
         onClearModifiedPages: () => void;
         clearAnnotationsChanges: () => void;
         onEmptyAreaClick: () => void;
@@ -240,6 +241,7 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
     );
 
     const [currentPage, setCurrentPage] = useState<number>(1);
+    const [currentOrderPageNumber, setCurrentOrderPageNumber] = useState<number>(0);
 
     const [annotationsChanges, setAnnotationsChanges] = useState<Record<number, Annotation[]>>({});
     const [modifiedPages, setModifiedPages] = useState<number[]>([]);
@@ -431,9 +433,14 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
         refetchLatestAnnotations
     } = documentData;
 
+    const onCurrentPageChange = (page: number, orderNumber: number) => {
+        setCurrentPage(page);
+        setCurrentOrderPageNumber(orderNumber);
+    };
+
     useEffect(() => {
         if (task || job || revisionId) {
-            setCurrentPage(pageNumbers[0]);
+            onCurrentPageChange(pageNumbers[0], 0);
             documentsResult.refetch();
         }
     }, [task, job, revisionId]);
@@ -1040,9 +1047,6 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
         }
     };
 
-    const onCurrentPageChange = (page: number) => {
-        setCurrentPage(page);
-    };
     const splitValidation = useSplitValidation({
         categories: categories,
         currentPage,
@@ -1142,6 +1146,7 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
             allAnnotations,
             pageNumbers,
             currentPage,
+            currentOrderPageNumber,
             pageSize,
             setPageSize,
             modifiedPages,
@@ -1221,6 +1226,7 @@ export const TaskAnnotatorContextProvider: React.FC<ProviderProps> = ({
         tokensByPages,
         allAnnotations,
         currentPage,
+        currentOrderPageNumber,
         pageSize,
         tableMode,
         isNeedToSaveTable,

--- a/web/src/pages/document/document-page.module.scss
+++ b/web/src/pages/document/document-page.module.scss
@@ -18,17 +18,6 @@
     }
 }
 
-.goto-page-selector {
-    span {
-        font-size: 12px;
-    }
-
-    & > :nth-child(2) {
-        margin: 0 6px;
-        width: 72px;
-    }
-}
-
 .document-page-content {
     flex: 1;
     display: grid;
@@ -36,26 +25,4 @@
     gap: 1rem;
     padding: 0 0 1rem 0;
     height: 0;
-}
-
-.button {
-    align-items: center;
-    box-shadow: none !important;
-    width: 24px;
-    height: 24px;
-    align-self: center;
-
-    :global(.uui-caption) {
-        font-size: 24px;
-        padding: 0;
-    }
-
-    &:first-of-type {
-        margin-left: 12px;
-        margin-right: 3px;
-    }
-
-    &:last-of-type {
-        margin-right: 32px;
-    }
 }

--- a/web/src/pages/document/document-page.tsx
+++ b/web/src/pages/document/document-page.tsx
@@ -1,6 +1,6 @@
 // temporary_disabled_rules
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 
 import {
     DocumentPageSidebarContent,
@@ -23,6 +23,7 @@ import { DocumentScale } from 'components/documents/document-scale/document-scal
 import { FlexRow } from '@epam/uui-components';
 
 import { DocumentToolbar } from 'shared/components/document-toolbar';
+import { TDocumentPDFRef } from 'shared/components/document-pages/components/document-pdf/types';
 
 export interface DocumentPageProps {
     fileMetaInfo: FileMetaInfo;
@@ -45,6 +46,7 @@ export function DocumentPage({
     documentJobsInfo,
     documentJobRevisionsInfo
 }: DocumentPageProps) {
+    const documentPDFRef = useRef<TDocumentPDFRef>(null);
     const [additionalScale, setAdditionalScale] = useState(0);
     const pages = fileMetaInfo.pages ?? 0;
 
@@ -54,7 +56,9 @@ export function DocumentPage({
         previousPageUrl?: string;
         previousPageName?: string;
     };
+
     const crumbs = [];
+
     if (historyState?.previousPage === PREVIOUS_PAGE_JOB) {
         crumbs.push({ name: 'Extractions', url: JOBS_PAGE });
         crumbs.push({
@@ -66,6 +70,10 @@ export function DocumentPage({
     }
 
     crumbs.push({ name: fileMetaInfo.name });
+
+    const onCurrentPageChange = useCallback((pageOrderNumber: number) => {
+        documentPDFRef.current?.scrollDocumentTo(pageOrderNumber);
+    }, []);
 
     return (
         <TaskAnnotatorContextProvider
@@ -81,7 +89,10 @@ export function DocumentPage({
                     <div className={styles['header__left-block']}>
                         <BreadcrumbNavigation breadcrumbs={crumbs} />
                         <FlexRow>
-                            <DocumentToolbar countOfPages={pages}></DocumentToolbar>
+                            <DocumentToolbar
+                                countOfPages={pages}
+                                onPageChange={onCurrentPageChange}
+                            ></DocumentToolbar>
                             <DocumentScale scale={additionalScale} onChange={setAdditionalScale} />
                         </FlexRow>
                     </div>
@@ -89,7 +100,11 @@ export function DocumentPage({
                 <div className={styles['document-page-content']}>
                     <TableAnnotatorContextProvider>
                         <FlowSideBar />
-                        <TaskDocumentPages additionalScale={additionalScale} viewMode={true} />
+                        <TaskDocumentPages
+                            additionalScale={additionalScale}
+                            viewMode={true}
+                            documentPDFRef={documentPDFRef}
+                        />
                         <TaskSidebar
                             viewMode={true}
                             jobSettings={

--- a/web/src/pages/document/document-page.tsx
+++ b/web/src/pages/document/document-page.tsx
@@ -19,7 +19,6 @@ import { useHistory } from 'react-router-dom';
 import { DOCUMENTS_PAGE, JOBS_PAGE, PREVIOUS_PAGE_JOB } from '../../shared/constants/general';
 import { BreadcrumbNavigation } from '../../shared/components/breadcrumb';
 import { FlowSideBar } from 'components/task/task-sidebar-flow/task-sidebar-flow';
-import { DocumentScale } from 'components/documents/document-scale/document-scale';
 import { FlexRow } from '@epam/uui-components';
 
 import { DocumentToolbar } from 'shared/components/document-toolbar';
@@ -91,9 +90,10 @@ export function DocumentPage({
                         <FlexRow>
                             <DocumentToolbar
                                 countOfPages={pages}
+                                scale={additionalScale}
                                 onPageChange={onCurrentPageChange}
+                                onScaleChange={setAdditionalScale}
                             ></DocumentToolbar>
-                            <DocumentScale scale={additionalScale} onChange={setAdditionalScale} />
                         </FlexRow>
                     </div>
                 </div>

--- a/web/src/pages/task/task-page.module.scss
+++ b/web/src/pages/task/task-page.module.scss
@@ -29,39 +29,6 @@
     }
 }
 
-.goto-page-selector {
-    span {
-        font-size: 12px;
-    }
-
-    & > :nth-child(2) {
-        margin: 0 6px;
-        width: 72px;
-    }
-}
-
-.button {
-    align-items: center;
-    box-shadow: none !important;
-    width: 24px;
-    height: 24px;
-    align-self: center;
-
-    :global(.uui-caption) {
-        font-size: 24px;
-        padding: 0;
-    }
-
-    &:first-of-type {
-        margin-left: 12px;
-        margin-right: 3px;
-    }
-
-    &:last-of-type {
-        margin-right: 32px;
-    }
-}
-
 .next-button {
     min-width: 51px !important;
 }

--- a/web/src/pages/task/task-page.tsx
+++ b/web/src/pages/task/task-page.tsx
@@ -24,14 +24,25 @@ import { ReactComponent as goNextIcon } from '@epam/assets/icons/common/navigati
 import { ReactComponent as goPrevIcon } from '@epam/assets/icons/common/navigation-chevron-up-18.svg';
 import { Labels } from 'shared/components/labels';
 import { FlexSpacer } from '@epam/uui-components';
+import { History } from 'history';
 
-const TaskPage: FC = () => {
+type TTaskPageContent = {
+    taskId: string;
+    handleRedirectToNextTask: () => void;
+    history: History<Record<string, string | undefined>>;
+    nextTaskId: number | undefined;
+};
+
+const TaskPageContent: FC<TTaskPageContent> = ({
+    taskId,
+    handleRedirectToNextTask,
+    history,
+    nextTaskId
+}) => {
     const [additionalScale, setAdditionalScale] = useState(0);
     const [gridVariant, setGridVariant] = useState(GridVariants.horizontal);
     const [goToPage, setGoToPage] = useState(1);
 
-    const { pathname } = useLocation();
-    const { taskId } = useParams<{ taskId: string }>();
     const taskData = useTaskById({ taskId: Number(taskId) }, { enabled: Boolean(taskId) })?.data;
     const isLastPage = goToPage === taskData?.pages.length;
     const isFirstPage = goToPage === 1;
@@ -66,6 +77,113 @@ const TaskPage: FC = () => {
         isFirstPage ? setGoToPage(1) : setGoToPage((prev) => prev - 1);
     }, [goToPage, taskData?.pages, isFirstPage]);
 
+    const crumbs = useMemo(() => {
+        const crumbs = [];
+        const { previousPage, previousPageName, previousPageUrl } = history.location.state ?? {};
+
+        if (previousPage === PREVIOUS_PAGE_JOB) {
+            crumbs.push({ name: 'Extractions', url: JOBS_PAGE });
+            crumbs.push({
+                name: previousPageName ?? '',
+                url: previousPageUrl
+            });
+        } else {
+            crumbs.push({ name: 'My Tasks', url: DASHBOARD_PAGE });
+        }
+
+        crumbs.push({ name: 'Task' });
+
+        return crumbs;
+    }, [history.location.state]);
+
+    return (
+        <div className="flex-col">
+            <div className={styles.title}>
+                <div className={styles['title__left-block']}>
+                    <FlexRow spacing="12" cx={styles['full-width']}>
+                        <FlexCell width="auto" minWidth={320}>
+                            <BreadcrumbNavigation breadcrumbs={crumbs} />
+                        </FlexCell>
+                        <FlexCell width="100%">
+                            <FlexRow>
+                                <Labels />
+                                <FlexSpacer />
+                                <FlexRow cx={styles['goto-page-selector']}>
+                                    <FlexCell minWidth={60}>
+                                        <span>Go to page</span>
+                                    </FlexCell>
+                                    <PickerInput
+                                        minBodyWidth={52}
+                                        size="24"
+                                        dataSource={pagesDataSource}
+                                        value={goToPage}
+                                        onValueChange={onPageChange}
+                                        getName={(item) => String(item)}
+                                        selectionMode="single"
+                                        disableClear={true}
+                                    />
+                                    <FlexRow>
+                                        <span>of {taskData?.pages.length}</span>
+                                        <Button
+                                            size="24"
+                                            fill="white"
+                                            icon={goPrevIcon}
+                                            cx={styles.button}
+                                            onClick={handleGoPrev}
+                                            isDisabled={isFirstPage}
+                                        />
+                                        <Button
+                                            size="24"
+                                            fill="white"
+                                            icon={goNextIcon}
+                                            cx={styles.button}
+                                            onClick={handleGoNext}
+                                            isDisabled={isLastPage}
+                                        />
+                                    </FlexRow>
+                                </FlexRow>
+                                <DocumentScale
+                                    scale={additionalScale}
+                                    onChange={setAdditionalScale}
+                                />
+                            </FlexRow>
+                        </FlexCell>
+                    </FlexRow>
+                </div>
+                <div className={styles['title__right-block']}>
+                    <div>
+                        <PickGridType value={gridVariant} onChange={setGridVariant} />
+                    </div>
+                    {nextTaskId && (
+                        <Button
+                            size="30"
+                            fill="white"
+                            caption="Next"
+                            cx={styles['next-button']}
+                            onClick={handleRedirectToNextTask}
+                        />
+                    )}
+                </div>
+            </div>
+            <div className={styles.content}>
+                <TableAnnotatorContextProvider>
+                    <FlowSideBar />
+                    <TaskDocumentPages
+                        viewMode={false}
+                        gridVariant={gridVariant}
+                        goToPage={goToPage}
+                        additionalScale={additionalScale}
+                    />
+                    <TaskSidebar viewMode={false} isNextTaskPresented={Boolean(nextTaskId)} />
+                </TableAnnotatorContextProvider>
+            </div>
+        </div>
+    );
+};
+
+const TaskPage: FC = () => {
+    const { pathname } = useLocation();
+    const { taskId } = useParams<{ taskId: string }>();
     const history = useHistory<Record<string, string | undefined>>();
     const { notifySuccess, notifyError } = useNotifications();
     const nextTaskId = useNextAndPreviousTask(taskId).data?.next_task?.id;
@@ -104,25 +222,6 @@ const TaskPage: FC = () => {
         );
     };
 
-    const crumbs = useMemo(() => {
-        const crumbs = [];
-        const { previousPage, previousPageName, previousPageUrl } = history.location.state ?? {};
-
-        if (previousPage === PREVIOUS_PAGE_JOB) {
-            crumbs.push({ name: 'Extractions', url: JOBS_PAGE });
-            crumbs.push({
-                name: previousPageName ?? '',
-                url: previousPageUrl
-            });
-        } else {
-            crumbs.push({ name: 'My Tasks', url: DASHBOARD_PAGE });
-        }
-
-        crumbs.push({ name: 'Task' });
-
-        return crumbs;
-    }, [history.location.state]);
-
     return (
         <TaskAnnotatorContextProvider
             taskId={Number(taskId)}
@@ -130,87 +229,12 @@ const TaskPage: FC = () => {
             onSaveTaskSuccess={handleSaveTaskSuccess}
             onSaveTaskError={handleSaveTaskError}
         >
-            <div className="flex-col">
-                <div className={styles.title}>
-                    <div className={styles['title__left-block']}>
-                        <FlexRow spacing="12" cx={styles['full-width']}>
-                            <FlexCell width="auto" minWidth={320}>
-                                <BreadcrumbNavigation breadcrumbs={crumbs} />
-                            </FlexCell>
-                            <FlexCell width="100%">
-                                <FlexRow>
-                                    <Labels />
-                                    <FlexSpacer />
-                                    <FlexRow cx={styles['goto-page-selector']}>
-                                        <FlexCell minWidth={60}>
-                                            <span>Go to page</span>
-                                        </FlexCell>
-                                        <PickerInput
-                                            minBodyWidth={52}
-                                            size="24"
-                                            dataSource={pagesDataSource}
-                                            value={goToPage}
-                                            onValueChange={onPageChange}
-                                            getName={(item) => String(item)}
-                                            selectionMode="single"
-                                            disableClear={true}
-                                        />
-                                        <FlexRow>
-                                            <span>of {taskData?.pages.length}</span>
-                                            <Button
-                                                size="24"
-                                                fill="white"
-                                                icon={goPrevIcon}
-                                                cx={styles.button}
-                                                onClick={handleGoPrev}
-                                                isDisabled={isFirstPage}
-                                            />
-                                            <Button
-                                                size="24"
-                                                fill="white"
-                                                icon={goNextIcon}
-                                                cx={styles.button}
-                                                onClick={handleGoNext}
-                                                isDisabled={isLastPage}
-                                            />
-                                        </FlexRow>
-                                    </FlexRow>
-                                    <DocumentScale
-                                        scale={additionalScale}
-                                        onChange={setAdditionalScale}
-                                    />
-                                </FlexRow>
-                            </FlexCell>
-                        </FlexRow>
-                    </div>
-                    <div className={styles['title__right-block']}>
-                        <div>
-                            <PickGridType value={gridVariant} onChange={setGridVariant} />
-                        </div>
-                        {nextTaskId && (
-                            <Button
-                                size="30"
-                                fill="white"
-                                caption="Next"
-                                cx={styles['next-button']}
-                                onClick={handleRedirectToNextTask}
-                            />
-                        )}
-                    </div>
-                </div>
-                <div className={styles.content}>
-                    <TableAnnotatorContextProvider>
-                        <FlowSideBar />
-                        <TaskDocumentPages
-                            viewMode={false}
-                            gridVariant={gridVariant}
-                            goToPage={goToPage}
-                            additionalScale={additionalScale}
-                        />
-                        <TaskSidebar viewMode={false} isNextTaskPresented={Boolean(nextTaskId)} />
-                    </TableAnnotatorContextProvider>
-                </div>
-            </div>
+            <TaskPageContent
+                taskId={taskId}
+                nextTaskId={nextTaskId}
+                history={history}
+                handleRedirectToNextTask={handleRedirectToNextTask}
+            ></TaskPageContent>
         </TaskAnnotatorContextProvider>
     );
 };

--- a/web/src/pages/task/task-page.tsx
+++ b/web/src/pages/task/task-page.tsx
@@ -1,11 +1,11 @@
 // temporary_disabled_rules
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps, react-hooks/rules-of-hooks */
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import TaskDocumentPages from 'components/task/task-document-pages/task-document-pages';
 import TaskSidebar from 'components/task/task-sidebar/task-sidebar';
 import { TaskAnnotatorContextProvider } from 'connectors/task-annotator-connector/task-annotator-context';
 import { matchPath, useHistory, useLocation, useParams } from 'react-router-dom';
-import { Button, Panel, Text, FlexCell, FlexRow, PickerInput } from '@epam/loveship';
+import { Button, Panel, Text, FlexCell, FlexRow } from '@epam/loveship';
 import { ApiError } from 'api/api-error';
 import { useNotifications } from 'shared/components/notifications';
 import { TableAnnotatorContextProvider } from '../../shared/components/annotator/context/table-annotator-context';
@@ -19,12 +19,10 @@ import { FlowSideBar } from 'components/task/task-sidebar-flow/task-sidebar-flow
 import { DocumentScale } from 'components/documents/document-scale/document-scale';
 import { PickGridType } from './picker-grid-type/picker-grid-type';
 import { GridVariants } from 'shared/constants/task';
-import { useArrayDataSource } from '@epam/uui';
-import { ReactComponent as goNextIcon } from '@epam/assets/icons/common/navigation-chevron-down-18.svg';
-import { ReactComponent as goPrevIcon } from '@epam/assets/icons/common/navigation-chevron-up-18.svg';
 import { Labels } from 'shared/components/labels';
 import { FlexSpacer } from '@epam/uui-components';
 import { History } from 'history';
+import { DocumentToolbar } from 'shared/components/document-toolbar';
 
 type TTaskPageContent = {
     taskId: string;
@@ -41,41 +39,8 @@ const TaskPageContent: FC<TTaskPageContent> = ({
 }) => {
     const [additionalScale, setAdditionalScale] = useState(0);
     const [gridVariant, setGridVariant] = useState(GridVariants.horizontal);
-    const [goToPage, setGoToPage] = useState(1);
 
     const taskData = useTaskById({ taskId: Number(taskId) }, { enabled: Boolean(taskId) })?.data;
-    const isLastPage = goToPage === taskData?.pages.length;
-    const isFirstPage = goToPage === 1;
-
-    const getPageNumbers = (pages = 1) => {
-        const data: { [key: string]: any } = {};
-
-        for (let i = 1; i <= pages; i++) {
-            data[`_${i}`] = i;
-        }
-
-        return data;
-    };
-
-    const pagesDataSource = useArrayDataSource(
-        {
-            items: Object.values(getPageNumbers(taskData?.pages.length)),
-            getId: (item) => item
-        },
-        []
-    );
-
-    const onPageChange = (page: any) => {
-        setGoToPage(page);
-    };
-
-    const handleGoNext = useCallback(() => {
-        isLastPage ? setGoToPage(taskData?.pages.length) : setGoToPage((prev) => prev + 1);
-    }, [goToPage, taskData?.pages, isLastPage]);
-
-    const handleGoPrev = useCallback(() => {
-        isFirstPage ? setGoToPage(1) : setGoToPage((prev) => prev - 1);
-    }, [goToPage, taskData?.pages, isFirstPage]);
 
     const crumbs = useMemo(() => {
         const crumbs = [];
@@ -108,40 +73,9 @@ const TaskPageContent: FC<TTaskPageContent> = ({
                             <FlexRow>
                                 <Labels />
                                 <FlexSpacer />
-                                <FlexRow cx={styles['goto-page-selector']}>
-                                    <FlexCell minWidth={60}>
-                                        <span>Go to page</span>
-                                    </FlexCell>
-                                    <PickerInput
-                                        minBodyWidth={52}
-                                        size="24"
-                                        dataSource={pagesDataSource}
-                                        value={goToPage}
-                                        onValueChange={onPageChange}
-                                        getName={(item) => String(item)}
-                                        selectionMode="single"
-                                        disableClear={true}
-                                    />
-                                    <FlexRow>
-                                        <span>of {taskData?.pages.length}</span>
-                                        <Button
-                                            size="24"
-                                            fill="white"
-                                            icon={goPrevIcon}
-                                            cx={styles.button}
-                                            onClick={handleGoPrev}
-                                            isDisabled={isFirstPage}
-                                        />
-                                        <Button
-                                            size="24"
-                                            fill="white"
-                                            icon={goNextIcon}
-                                            cx={styles.button}
-                                            onClick={handleGoNext}
-                                            isDisabled={isLastPage}
-                                        />
-                                    </FlexRow>
-                                </FlexRow>
+                                <DocumentToolbar
+                                    countOfPages={taskData?.pages.length ?? 0}
+                                ></DocumentToolbar>
                                 <DocumentScale
                                     scale={additionalScale}
                                     onChange={setAdditionalScale}
@@ -171,7 +105,6 @@ const TaskPageContent: FC<TTaskPageContent> = ({
                     <TaskDocumentPages
                         viewMode={false}
                         gridVariant={gridVariant}
-                        goToPage={goToPage}
                         additionalScale={additionalScale}
                     />
                     <TaskSidebar viewMode={false} isNextTaskPresented={Boolean(nextTaskId)} />

--- a/web/src/pages/task/task-page.tsx
+++ b/web/src/pages/task/task-page.tsx
@@ -81,12 +81,10 @@ const TaskPageContent: FC<TTaskPageContent> = ({
                                 <FlexSpacer />
                                 <DocumentToolbar
                                     countOfPages={taskData?.pages.length ?? 0}
-                                    onPageChange={onCurrentPageChange}
-                                ></DocumentToolbar>
-                                <DocumentScale
                                     scale={additionalScale}
-                                    onChange={setAdditionalScale}
-                                />
+                                    onPageChange={onCurrentPageChange}
+                                    onScaleChange={setAdditionalScale}
+                                ></DocumentToolbar>
                             </FlexRow>
                         </FlexCell>
                     </FlexRow>

--- a/web/src/pages/task/task-page.tsx
+++ b/web/src/pages/task/task-page.tsx
@@ -1,6 +1,6 @@
 // temporary_disabled_rules
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-redeclare, react-hooks/exhaustive-deps, react-hooks/rules-of-hooks */
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import TaskDocumentPages from 'components/task/task-document-pages/task-document-pages';
 import TaskSidebar from 'components/task/task-sidebar/task-sidebar';
 import { TaskAnnotatorContextProvider } from 'connectors/task-annotator-connector/task-annotator-context';
@@ -23,6 +23,7 @@ import { Labels } from 'shared/components/labels';
 import { FlexSpacer } from '@epam/uui-components';
 import { History } from 'history';
 import { DocumentToolbar } from 'shared/components/document-toolbar';
+import { TDocumentPDFRef } from 'shared/components/document-pages/components/document-pdf/types';
 
 type TTaskPageContent = {
     taskId: string;
@@ -37,10 +38,15 @@ const TaskPageContent: FC<TTaskPageContent> = ({
     history,
     nextTaskId
 }) => {
+    const documentPDFRef = useRef<TDocumentPDFRef>(null);
     const [additionalScale, setAdditionalScale] = useState(0);
     const [gridVariant, setGridVariant] = useState(GridVariants.horizontal);
 
     const taskData = useTaskById({ taskId: Number(taskId) }, { enabled: Boolean(taskId) })?.data;
+
+    const onCurrentPageChange = useCallback((pageOrderNumber: number) => {
+        documentPDFRef.current?.scrollDocumentTo(pageOrderNumber);
+    }, []);
 
     const crumbs = useMemo(() => {
         const crumbs = [];
@@ -75,6 +81,7 @@ const TaskPageContent: FC<TTaskPageContent> = ({
                                 <FlexSpacer />
                                 <DocumentToolbar
                                     countOfPages={taskData?.pages.length ?? 0}
+                                    onPageChange={onCurrentPageChange}
                                 ></DocumentToolbar>
                                 <DocumentScale
                                     scale={additionalScale}
@@ -106,6 +113,7 @@ const TaskPageContent: FC<TTaskPageContent> = ({
                         viewMode={false}
                         gridVariant={gridVariant}
                         additionalScale={additionalScale}
+                        documentPDFRef={documentPDFRef}
                     />
                     <TaskSidebar viewMode={false} isNextTaskPresented={Boolean(nextTaskId)} />
                 </TableAnnotatorContextProvider>

--- a/web/src/shared/components/document-pages/components/document-pdf/index.tsx
+++ b/web/src/shared/components/document-pages/components/document-pdf/index.tsx
@@ -22,7 +22,6 @@ type DocumentPDFProps = {
     handleDocumentLoaded: DocumentLoadedCallback;
     fileMetaInfo: FileMetaInfo;
     pageSize?: PageSize;
-    goToPage?: number;
     editable: boolean;
     fullScale: number;
     containerRef: {
@@ -96,14 +95,14 @@ const DocumentPDF: React.FC<DocumentPDFProps> = ({
     pageSize,
     handleDocumentLoaded,
     containerRef,
-    editable,
-    goToPage
+    editable
 }) => {
     const {
         selectedAnnotation,
         setAvailableRenderedPagesRange,
         getNextDocumentItems,
-        isDocumentPageDataLoaded
+        isDocumentPageDataLoaded,
+        currentOrderPageNumber
     } = useTaskAnnotatorContext();
     const pdfListData = useMemo<ListItemData>(
         () => ({
@@ -125,7 +124,7 @@ const DocumentPDF: React.FC<DocumentPDFProps> = ({
     const loadMoreItems = useDebouncedCallback(getNextDocumentItems, 500);
 
     /**
-     * goToPage - the ordering number of page which is currently shown on UI (starts from 1),
+     * currentOrderPageNumber - the ordering number of page which is currently shown on UI,
      * correlate with "pageNumbers (indexes)"
      * pageNumbers (values) - number of page comes from BE (can be started from any number
      * and contains numbers only for processed pages)
@@ -137,8 +136,8 @@ const DocumentPDF: React.FC<DocumentPDFProps> = ({
 
     // in case of page switching
     useEffect(() => {
-        pdfPagesListRef.current?.scrollToItem(goToPage! - 1, 'start');
-    }, [goToPage]);
+        pdfPagesListRef.current?.scrollToItem(currentOrderPageNumber, 'start');
+    }, [currentOrderPageNumber]);
 
     // in case of scrolling to some annotation
     useEffect(() => {

--- a/web/src/shared/components/document-pages/components/document-pdf/index.tsx
+++ b/web/src/shared/components/document-pages/components/document-pdf/index.tsx
@@ -48,10 +48,10 @@ const fixedSizeListStyle = { willChange: 'auto' };
 
 const PDFPageRenderer: FC<PDFPageRendererProps> = ({
     data: { pageNumbers, fullScale, pageSize, containerRef, editable },
-    index,
+    index: orderNumber,
     style
 }) => {
-    const pageNum = pageNumbers[index];
+    const pageNum = pageNumbers[orderNumber];
     const {
         onEmptyAreaClick,
         onAnnotationCopyPress,
@@ -67,6 +67,7 @@ const PDFPageRenderer: FC<PDFPageRendererProps> = ({
                 scale={fullScale}
                 pageSize={pageSize}
                 pageNum={pageNum}
+                orderNumber={orderNumber}
                 containerRef={containerRef}
                 editable={editable}
                 onAnnotationCopyPress={onAnnotationCopyPress}

--- a/web/src/shared/components/document-pages/components/document-pdf/index.tsx
+++ b/web/src/shared/components/document-pages/components/document-pdf/index.tsx
@@ -1,8 +1,16 @@
 // temporary_disabled_rules
 /* eslint-disable @typescript-eslint/no-redeclare */
-import React, { CSSProperties, FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+    FC,
+    forwardRef,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState
+} from 'react';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
-import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';
 import { Document } from 'react-pdf';
 import { FixedSizeList } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -12,33 +20,11 @@ import { getPdfDocumentAddress } from 'shared/helpers/get-pdf-document-address';
 import DocumentSinglePage from '../../document-single-page';
 import { Spinner } from '@epam/loveship';
 import { ANNOTATION_LABEL_ID_PREFIX } from 'shared/constants/annotations';
-import { PageSize, DocumentLoadedCallback } from '../../types';
+import { PageSize } from '../../types';
 import { Annotation } from 'shared/components/annotator';
 import { useDebouncedCallback } from 'use-debounce';
 import { scrollIntoViewIfNeeded } from 'shared/helpers/scroll-into-view-if-needed';
-
-type DocumentPDFProps = {
-    pageNumbers: number[];
-    handleDocumentLoaded: DocumentLoadedCallback;
-    fileMetaInfo: FileMetaInfo;
-    pageSize?: PageSize;
-    editable: boolean;
-    fullScale: number;
-    containerRef: {
-        current: HTMLDivElement | null;
-    };
-};
-
-type ListItemData = Pick<
-    DocumentPDFProps,
-    'pageNumbers' | 'fullScale' | 'pageSize' | 'containerRef' | 'editable'
->;
-
-type PDFPageRendererProps = {
-    data: ListItemData;
-    index: number;
-    style: CSSProperties;
-};
+import { TDocumentPDFRef, DocumentPDFProps, ListItemData, PDFPageRendererProps } from './types';
 
 // "willChange: transform" set by react-window is removed
 // to not create a new stacking context which may affect
@@ -88,156 +74,168 @@ const getAnnotationLabelElement = ({ id }: { id: Annotation['id'] }): HTMLDivEle
 const LOADING_THRESHOLD_BUFFER = 2;
 const OVERSCAN_RENDERED_PAGES_COUNT = 5;
 
-const DocumentPDF: React.FC<DocumentPDFProps> = ({
-    fileMetaInfo,
-    pageNumbers,
-    fullScale,
-    pageSize,
-    handleDocumentLoaded,
-    containerRef,
-    editable
-}) => {
-    const {
-        selectedAnnotation,
-        setAvailableRenderedPagesRange,
-        getNextDocumentItems,
-        isDocumentPageDataLoaded,
-        currentOrderPageNumber
-    } = useTaskAnnotatorContext();
-    const pdfListData = useMemo<ListItemData>(
-        () => ({
+const DocumentPDF = forwardRef<TDocumentPDFRef, DocumentPDFProps>(
+    (
+        {
+            fileMetaInfo,
             pageNumbers,
             fullScale,
             pageSize,
+            handleDocumentLoaded,
             containerRef,
             editable
-        }),
-        [pageNumbers, fullScale, pageSize, containerRef, editable]
-    );
-    const apiToUiPageNumbersMap = useMemo(() => {
-        const map = pageNumbers.map((apiPageNum, uiPageNum) => [apiPageNum, uiPageNum] as const);
-        return new Map(map);
-    }, [pageNumbers]);
-    const pdfPagesListRef = useRef<FixedSizeList | null>(null);
-    const listViewContainerRef = useRef<HTMLDivElement>(null);
-    const itemSize = Number(pageSize ? pageSize.height : 0) * fullScale;
-    const loadMoreItems = useDebouncedCallback(getNextDocumentItems, 500);
-
-    /**
-     * currentOrderPageNumber - the ordering number of page which is currently shown on UI,
-     * correlate with "pageNumbers (indexes)"
-     * pageNumbers (values) - number of page comes from BE (can be started from any number
-     * and contains numbers only for processed pages)
-     * pageNumbers (indexes) - index of pageNumbers is a mapping to page numbers which comes from BE
-     *
-     * Example: [0: 22, 1: 23, 2: 25, 3: 28] (index - number of rendered page (actually, index + 1),
-     * value - number of the page from BE)
-     */
-
-    // in case of page switching
-    useEffect(() => {
-        pdfPagesListRef.current?.scrollToItem(currentOrderPageNumber, 'start');
-    }, [currentOrderPageNumber]);
-
-    // in case of scrolling to some annotation
-    useEffect(() => {
-        // give the browser chance to make additional painting (to wait for changes with
-        // annotations like creation of new annotation)
-        requestAnimationFrame(() => {
-            if (!selectedAnnotation || !pdfPagesListRef.current || !listViewContainerRef.current) {
-                return;
-            }
-
-            const label = getAnnotationLabelElement(selectedAnnotation);
-
-            if (label) {
-                scrollIntoViewIfNeeded(listViewContainerRef.current, label);
-            } else {
-                const pageNum = apiToUiPageNumbersMap.get(selectedAnnotation.pageNum!)!;
-                pdfPagesListRef.current.scrollToItem(pageNum - 1);
-
-                // scroll to the annotation (in X and Y dimension) in async mode since
-                // need to wait until scrollToItem() method loads the page -> DOM will
-                // be ready with needed annotation
-                requestAnimationFrame(() => {
-                    getAnnotationLabelElement(selectedAnnotation)?.scrollIntoView();
-                });
-            }
-        });
-    }, [apiToUiPageNumbersMap, selectedAnnotation]);
-
-    const [isDocumentLoaded, setIsDocumentLoaded] = useState(false);
-    const onDocumentLoadSuccess = useCallback(
-        (pdf) => {
-            handleDocumentLoaded(pdf);
-            setIsDocumentLoaded(true);
         },
-        [handleDocumentLoaded]
-    );
+        ref
+    ) => {
+        const {
+            selectedAnnotation,
+            setAvailableRenderedPagesRange,
+            getNextDocumentItems,
+            isDocumentPageDataLoaded
+        } = useTaskAnnotatorContext();
+        const pdfListData = useMemo<ListItemData>(
+            () => ({
+                pageNumbers,
+                fullScale,
+                pageSize,
+                containerRef,
+                editable
+            }),
+            [pageNumbers, fullScale, pageSize, containerRef, editable]
+        );
+        const apiToUiPageNumbersMap = useMemo(() => {
+            const map = pageNumbers.map(
+                (apiPageNum, uiPageNum) => [apiPageNum, uiPageNum] as const
+            );
+            return new Map(map);
+        }, [pageNumbers]);
+        const pdfPagesListRef = useRef<FixedSizeList | null>(null);
+        const listViewContainerRef = useRef<HTMLDivElement>(null);
+        const itemSize = Number(pageSize ? pageSize.height : 0) * fullScale;
+        const loadMoreItems = useDebouncedCallback(getNextDocumentItems, 500);
 
-    const isDocumentReadyForRender = isDocumentLoaded && itemSize > 0;
+        useImperativeHandle(ref, () => ({
+            scrollDocumentTo(index) {
+                pdfPagesListRef.current?.scrollToItem(index, 'start');
+            }
+        }));
 
-    return (
-        <>
-            <Document
-                file={getPdfDocumentAddress(fileMetaInfo.id)}
-                loading={
-                    <div className="flex-cell">
-                        <Spinner color="sky" />
-                    </div>
+        /**
+         * pageNumbers (values) - number of page comes from BE (can be started from any number
+         * and contains numbers only for processed pages)
+         * pageNumbers (indexes) - index of pageNumbers is a mapping to page numbers which comes from BE
+         *
+         * Example: [0: 22, 1: 23, 2: 25, 3: 28] (index - number of rendered page (actually, index + 1),
+         * value - number of the page from BE)
+         */
+
+        // in case of scrolling to some annotation
+        useEffect(() => {
+            // give the browser chance to make additional painting (to wait for changes with
+            // annotations like creation of new annotation)
+            requestAnimationFrame(() => {
+                if (
+                    !selectedAnnotation ||
+                    !pdfPagesListRef.current ||
+                    !listViewContainerRef.current
+                ) {
+                    return;
                 }
-                onLoadSuccess={onDocumentLoadSuccess}
-                options={{ httpHeaders: getAuthHeaders() }}
-            >
-                {isDocumentReadyForRender && (
-                    <AutoSizer>
-                        {({ width, height }: PageSize) => {
-                            const countOfVisiblePages = Math.ceil(height / itemSize);
-                            const loadingThreshold = countOfVisiblePages + LOADING_THRESHOLD_BUFFER;
 
-                            return (
-                                <InfiniteLoader
-                                    isItemLoaded={isDocumentPageDataLoaded}
-                                    itemCount={pageNumbers.length}
-                                    loadMoreItems={loadMoreItems}
-                                    threshold={loadingThreshold}
-                                    minimumBatchSize={
-                                        countOfVisiblePages + OVERSCAN_RENDERED_PAGES_COUNT
-                                    }
-                                >
-                                    {({ onItemsRendered, ref }) => (
-                                        <FixedSizeList
-                                            ref={(listRef) => {
-                                                ref(listRef);
-                                                pdfPagesListRef.current = listRef;
-                                            }}
-                                            outerRef={listViewContainerRef}
-                                            onItemsRendered={(props) => {
-                                                setAvailableRenderedPagesRange({
-                                                    begin: props.overscanStartIndex,
-                                                    end: props.overscanStopIndex
-                                                });
-                                                onItemsRendered(props);
-                                            }}
-                                            width={width}
-                                            height={height}
-                                            itemCount={pageNumbers.length}
-                                            itemData={pdfListData}
-                                            overscanCount={OVERSCAN_RENDERED_PAGES_COUNT}
-                                            style={fixedSizeListStyle}
-                                            itemSize={itemSize}
-                                        >
-                                            {PDFPageRenderer}
-                                        </FixedSizeList>
-                                    )}
-                                </InfiniteLoader>
-                            );
-                        }}
-                    </AutoSizer>
-                )}
-            </Document>
-        </>
-    );
-};
+                const label = getAnnotationLabelElement(selectedAnnotation);
+
+                if (label) {
+                    scrollIntoViewIfNeeded(listViewContainerRef.current, label);
+                } else {
+                    const pageNum = apiToUiPageNumbersMap.get(selectedAnnotation.pageNum!)!;
+                    pdfPagesListRef.current.scrollToItem(pageNum - 1);
+
+                    // scroll to the annotation (in X and Y dimension) in async mode since
+                    // need to wait until scrollToItem() method loads the page -> DOM will
+                    // be ready with needed annotation
+                    requestAnimationFrame(() => {
+                        getAnnotationLabelElement(selectedAnnotation)?.scrollIntoView();
+                    });
+                }
+            });
+        }, [apiToUiPageNumbersMap, selectedAnnotation]);
+
+        const [isDocumentLoaded, setIsDocumentLoaded] = useState(false);
+        const onDocumentLoadSuccess = useCallback(
+            (pdf) => {
+                handleDocumentLoaded(pdf);
+                setIsDocumentLoaded(true);
+            },
+            [handleDocumentLoaded]
+        );
+
+        const isDocumentReadyForRender = isDocumentLoaded && itemSize > 0;
+
+        return (
+            <>
+                <Document
+                    file={getPdfDocumentAddress(fileMetaInfo.id)}
+                    loading={
+                        <div className="flex-cell">
+                            <Spinner color="sky" />
+                        </div>
+                    }
+                    onLoadSuccess={onDocumentLoadSuccess}
+                    options={{ httpHeaders: getAuthHeaders() }}
+                >
+                    {isDocumentReadyForRender && (
+                        <AutoSizer>
+                            {({ width, height }: PageSize) => {
+                                const countOfVisiblePages = Math.ceil(height / itemSize);
+                                const loadingThreshold =
+                                    countOfVisiblePages + LOADING_THRESHOLD_BUFFER;
+
+                                return (
+                                    <InfiniteLoader
+                                        isItemLoaded={isDocumentPageDataLoaded}
+                                        itemCount={pageNumbers.length}
+                                        loadMoreItems={loadMoreItems}
+                                        threshold={loadingThreshold}
+                                        minimumBatchSize={
+                                            countOfVisiblePages + OVERSCAN_RENDERED_PAGES_COUNT
+                                        }
+                                    >
+                                        {({ onItemsRendered, ref }) => (
+                                            <FixedSizeList
+                                                ref={(listRef) => {
+                                                    ref(listRef);
+                                                    pdfPagesListRef.current = listRef;
+                                                }}
+                                                outerRef={listViewContainerRef}
+                                                onItemsRendered={(props) => {
+                                                    setAvailableRenderedPagesRange({
+                                                        begin: props.overscanStartIndex,
+                                                        end: props.overscanStopIndex
+                                                    });
+                                                    onItemsRendered(props);
+                                                }}
+                                                width={width}
+                                                height={height}
+                                                itemCount={pageNumbers.length}
+                                                itemData={pdfListData}
+                                                overscanCount={OVERSCAN_RENDERED_PAGES_COUNT}
+                                                style={fixedSizeListStyle}
+                                                itemSize={itemSize}
+                                            >
+                                                {PDFPageRenderer}
+                                            </FixedSizeList>
+                                        )}
+                                    </InfiniteLoader>
+                                );
+                            }}
+                        </AutoSizer>
+                    )}
+                </Document>
+            </>
+        );
+    }
+);
+
+DocumentPDF.displayName = 'DocumentPDF';
 
 export default DocumentPDF;

--- a/web/src/shared/components/document-pages/components/document-pdf/types.ts
+++ b/web/src/shared/components/document-pages/components/document-pdf/types.ts
@@ -1,0 +1,30 @@
+import { CSSProperties } from 'react';
+import { DocumentLoadedCallback, PageSize } from '../../types';
+import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';
+
+export type DocumentPDFProps = {
+    pageNumbers: number[];
+    handleDocumentLoaded: DocumentLoadedCallback;
+    fileMetaInfo: FileMetaInfo;
+    pageSize?: PageSize;
+    editable: boolean;
+    fullScale: number;
+    containerRef: {
+        current: HTMLDivElement | null;
+    };
+};
+
+export type ListItemData = Pick<
+    DocumentPDFProps,
+    'pageNumbers' | 'fullScale' | 'pageSize' | 'containerRef' | 'editable'
+>;
+
+export type PDFPageRendererProps = {
+    data: ListItemData;
+    index: number;
+    style: CSSProperties;
+};
+
+export type TDocumentPDFRef = {
+    scrollDocumentTo(index: number): void;
+};

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -55,7 +55,6 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
         onAnnotationUndoPress,
         onAnnotationRedoPress
     } = useTaskAnnotatorContext();
-    const goToPage = currentOrderPageNumber + 1;
     const containerRef = useRef<HTMLDivElement>(null);
 
     const [scale, setScale] = useState(0);
@@ -163,7 +162,9 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                             onAnnotationUndoPress={onAnnotationUndoPress}
                                             onAnnotationRedoPress={onAnnotationRedoPress}
                                             onEmptyAreaClick={onEmptyAreaClick}
-                                            isScrolledToCurrent={pageNum === goToPage}
+                                            isScrolledToCurrent={
+                                                pageNum === currentOrderPageNumber + 1
+                                            }
                                         />
                                     </Fragment>
                                 );
@@ -204,7 +205,9 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                                         scaledAnn
                                                     )
                                                 }
-                                                isScrolledToCurrent={pageNum === goToPage}
+                                                isScrolledToCurrent={
+                                                    pageNum === currentOrderPageNumber + 1
+                                                }
                                             />
                                         );
                                     })}
@@ -278,7 +281,6 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                 handleDocumentLoaded={handleDocumentLoaded}
                                 containerRef={containerRef}
                                 editable={editable}
-                                goToPage={goToPage}
                             />
                         ) : null}
                         {fileMetaInfo.extension === '.jpg' ? (
@@ -302,7 +304,9 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                                 onAnnotationUndoPress={onAnnotationUndoPress}
                                                 onAnnotationRedoPress={onAnnotationRedoPress}
                                                 onEmptyAreaClick={onEmptyAreaClick}
-                                                isScrolledToCurrent={pageNum === goToPage}
+                                                isScrolledToCurrent={
+                                                    pageNum === currentOrderPageNumber + 1
+                                                }
                                             />
                                         </Fragment>
                                     );

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -163,9 +163,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                             onAnnotationUndoPress={onAnnotationUndoPress}
                                             onAnnotationRedoPress={onAnnotationRedoPress}
                                             onEmptyAreaClick={onEmptyAreaClick}
-                                            isScrolledToCurrent={
-                                                pageNum === currentOrderPageNumber + 1
-                                            }
+                                            isScrolledToCurrent={pageNum === currentPage}
                                         />
                                     </Fragment>
                                 );
@@ -206,9 +204,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                                         scaledAnn
                                                     )
                                                 }
-                                                isScrolledToCurrent={
-                                                    pageNum === currentOrderPageNumber + 1
-                                                }
+                                                isScrolledToCurrent={pageNum === currentPage}
                                             />
                                         );
                                     })}
@@ -306,9 +302,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                                 onAnnotationUndoPress={onAnnotationUndoPress}
                                                 onAnnotationRedoPress={onAnnotationRedoPress}
                                                 onEmptyAreaClick={onEmptyAreaClick}
-                                                isScrolledToCurrent={
-                                                    pageNum === currentOrderPageNumber + 1
-                                                }
+                                                isScrolledToCurrent={pageNum === currentPage}
                                             />
                                         </Fragment>
                                     );

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -46,6 +46,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
         latestRevisionByAnnotators,
         latestRevisionByAnnotatorsWithBounds,
         currentPage,
+        currentOrderPageNumber,
         selectedRelatedDoc,
         job,
         onEmptyAreaClick,
@@ -145,13 +146,14 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                             rowsCount={latestRevisionByAnnotators.length + 1}
                             className={styles['split-document-page']}
                         >
-                            {pageNumbers.map((pageNum) => {
+                            {pageNumbers.map((pageNum, orderNumber) => {
                                 return (
                                     <Fragment key={`validation-${pageNum}`}>
                                         <DocumentSinglePage
                                             scale={fullScale}
                                             pageSize={apiPageSize}
                                             pageNum={pageNum}
+                                            orderNumber={orderNumber}
                                             handlePageLoaded={handlePageLoaded}
                                             containerRef={containerRef}
                                             editable
@@ -178,7 +180,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                         styles['additional-page']
                                     )}
                                 >
-                                    {pageNumbers.map((pageNum) => {
+                                    {pageNumbers.map((pageNum, orderNumber) => {
                                         const isShowAnnotation =
                                             !!latestRevisionByAnnotatorsWithBounds[userId].filter(
                                                 (obj) => obj.pageNum === pageNum
@@ -189,6 +191,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                                 key={`${userId}-${pageNum}`}
                                                 scale={fullScale}
                                                 pageNum={pageNum}
+                                                orderNumber={orderNumber}
                                                 pageSize={apiPageSize}
                                                 userId={userId}
                                                 isShownAnnotation={isShowAnnotation}
@@ -227,6 +230,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                     scale={fullScale}
                                     pageSize={apiPageSize}
                                     pageNum={currentPage}
+                                    orderNumber={currentOrderPageNumber}
                                     handlePageLoaded={handlePageLoaded}
                                     containerRef={containerRef}
                                     editable
@@ -250,6 +254,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                                     scale={fullScale}
                                     pageSize={apiPageSize}
                                     pageNum={currentPage}
+                                    orderNumber={currentOrderPageNumber}
                                     handlePageLoaded={handlePageLoaded}
                                     containerRef={containerRef}
                                     editable={false}
@@ -279,13 +284,14 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                         ) : null}
                         {fileMetaInfo.extension === '.jpg' ? (
                             <div className={styles['images-container']}>
-                                {pageNumbers.map((pageNum) => {
+                                {pageNumbers.map((pageNum, orderNumber) => {
                                     return (
                                         <Fragment key={pageNum}>
                                             <DocumentSinglePage
                                                 scale={fullScale}
                                                 pageSize={apiPageSize}
                                                 pageNum={pageNum}
+                                                orderNumber={orderNumber}
                                                 handlePageLoaded={handlePageLoaded}
                                                 containerRef={containerRef}
                                                 editable={editable}

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -36,7 +36,8 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
     setPageSize,
     editable,
     gridVariant,
-    additionalScale
+    additionalScale,
+    documentPDFRef
 }) => {
     const {
         SyncedContainer,
@@ -274,6 +275,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
                     <>
                         {fileMetaInfo.extension === '.pdf' ? (
                             <DocumentPDF
+                                ref={documentPDFRef}
                                 fileMetaInfo={fileMetaInfo}
                                 pageNumbers={pageNumbers}
                                 fullScale={fullScale}

--- a/web/src/shared/components/document-pages/document-pages.tsx
+++ b/web/src/shared/components/document-pages/document-pages.tsx
@@ -36,8 +36,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
     setPageSize,
     editable,
     gridVariant,
-    additionalScale,
-    goToPage
+    additionalScale
 }) => {
     const {
         SyncedContainer,
@@ -56,7 +55,7 @@ const DocumentPages: React.FC<DocumentPagesProps> = ({
         onAnnotationUndoPress,
         onAnnotationRedoPress
     } = useTaskAnnotatorContext();
-
+    const goToPage = currentOrderPageNumber + 1;
     const containerRef = useRef<HTMLDivElement>(null);
 
     const [scale, setScale] = useState(0);

--- a/web/src/shared/components/document-pages/document-single-page.tsx
+++ b/web/src/shared/components/document-pages/document-single-page.tsx
@@ -16,6 +16,7 @@ type RenderPageParams = {
     annotations?: Annotation[];
     scale: number;
     pageNum: number;
+    orderNumber: number;
     handlePageLoaded?: (page: PDFPageProxy | HTMLImageElement) => void;
     pageSize?: PageSize;
     containerRef?: React.RefObject<HTMLDivElement>;
@@ -42,6 +43,7 @@ const DocumentSinglePage: FC<RenderPageParams> = ({
     annotations,
     scale,
     pageNum,
+    orderNumber,
     userId,
     handlePageLoaded = noop,
     pageSize,
@@ -167,7 +169,7 @@ const DocumentSinglePage: FC<RenderPageParams> = ({
             id="document-page"
             rootRef={containerRef}
             onIntersect={() => {
-                onCurrentPageChange(pageNum);
+                onCurrentPageChange(pageNum, orderNumber);
             }}
             disabled={!pageSize}
             width={pageSize ? pageSize.width * scale : undefined}

--- a/web/src/shared/components/document-pages/types.ts
+++ b/web/src/shared/components/document-pages/types.ts
@@ -1,8 +1,9 @@
-import { ReactNode } from 'react';
+import { ReactNode, RefObject } from 'react';
 import { FileMetaInfo } from 'pages/document/document-page-sidebar-content/document-page-sidebar-content';
 import { PDFPageProxy, DocumentProps } from 'react-pdf';
 import { Annotation } from 'shared';
 import { GridVariants } from 'shared/constants/task';
+import { TDocumentPDFRef } from './components/document-pdf/types';
 
 type RenderLinksParams = {
     updLinks: boolean;
@@ -24,6 +25,7 @@ export type DocumentPagesProps = {
     setPageSize?: (nS: any) => void;
     editable: boolean;
     gridVariant: GridVariants;
+    documentPDFRef: RefObject<TDocumentPDFRef> | null;
 };
 
 export type PageLoadedCallback = (page: PDFPageProxy | HTMLImageElement) => void;

--- a/web/src/shared/components/document-pages/types.ts
+++ b/web/src/shared/components/document-pages/types.ts
@@ -21,7 +21,6 @@ export type DocumentPagesProps = {
     fileMetaInfo: FileMetaInfo;
     apiPageSize?: PageSize;
     additionalScale: number;
-    goToPage?: number;
     setPageSize?: (nS: any) => void;
     editable: boolean;
     gridVariant: GridVariants;

--- a/web/src/shared/components/document-toolbar/index.tsx
+++ b/web/src/shared/components/document-toolbar/index.tsx
@@ -1,0 +1,78 @@
+import { FC, useCallback } from 'react';
+import { FlexRow } from '@epam/uui-components';
+import { Button, FlexCell, PickerInput } from '@epam/loveship';
+import styles from './styles.module.scss';
+import { useArrayDataSource } from '@epam/uui';
+import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
+
+import { ReactComponent as goNextIcon } from '@epam/assets/icons/common/navigation-chevron-down-18.svg';
+import { ReactComponent as goPrevIcon } from '@epam/assets/icons/common/navigation-chevron-up-18.svg';
+
+export const DocumentToolbar: FC<{ countOfPages: number }> = ({ countOfPages }) => {
+    const { currentOrderPageNumber, pageNumbers, onCurrentPageChange } = useTaskAnnotatorContext();
+    const isLastPage = currentOrderPageNumber === countOfPages - 1;
+    const isFirstPage = currentOrderPageNumber === 0;
+
+    const pagesDataSource = useArrayDataSource(
+        {
+            items: Array.from({ length: countOfPages }).map((_, index) => index + 1),
+            getId: (item) => item
+        },
+        []
+    );
+
+    const onPageChange = (selectedPageNumber: number) => {
+        const pageOrderNumber = selectedPageNumber - 1;
+
+        onCurrentPageChange(pageNumbers[pageOrderNumber], pageOrderNumber);
+    };
+
+    const handleGoNext = useCallback(() => {
+        const nextOrderNumber = isLastPage ? countOfPages - 1 : currentOrderPageNumber + 1;
+
+        onCurrentPageChange(pageNumbers[nextOrderNumber], nextOrderNumber);
+    }, [isLastPage, countOfPages, currentOrderPageNumber, onCurrentPageChange, pageNumbers]);
+
+    const handleGoPrev = useCallback(() => {
+        const nextOrderNumber = isFirstPage ? 0 : currentOrderPageNumber - 1;
+
+        onCurrentPageChange(pageNumbers[nextOrderNumber], nextOrderNumber);
+    }, [isFirstPage, currentOrderPageNumber, onCurrentPageChange, pageNumbers]);
+
+    return (
+        <FlexRow cx={styles['goto-page-selector']}>
+            <FlexCell minWidth={60}>
+                <span>Go to page</span>
+            </FlexCell>
+            <PickerInput
+                minBodyWidth={52}
+                size="24"
+                dataSource={pagesDataSource}
+                value={currentOrderPageNumber + 1}
+                onValueChange={onPageChange}
+                getName={(item) => String(item)}
+                selectionMode="single"
+                disableClear={true}
+            />
+            <FlexRow>
+                <span>of {countOfPages}</span>
+                <Button
+                    size="24"
+                    fill="white"
+                    icon={goPrevIcon}
+                    cx={styles.button}
+                    onClick={handleGoPrev}
+                    isDisabled={isFirstPage}
+                />
+                <Button
+                    size="24"
+                    fill="white"
+                    icon={goNextIcon}
+                    cx={styles.button}
+                    onClick={handleGoNext}
+                    isDisabled={isLastPage}
+                />
+            </FlexRow>
+        </FlexRow>
+    );
+};

--- a/web/src/shared/components/document-toolbar/index.tsx
+++ b/web/src/shared/components/document-toolbar/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import { FC, SetStateAction, useCallback } from 'react';
 import { FlexRow } from '@epam/uui-components';
 import { Button, FlexCell, PickerInput } from '@epam/loveship';
 import styles from './styles.module.scss';
@@ -7,13 +7,21 @@ import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/tas
 
 import { ReactComponent as goNextIcon } from '@epam/assets/icons/common/navigation-chevron-down-18.svg';
 import { ReactComponent as goPrevIcon } from '@epam/assets/icons/common/navigation-chevron-up-18.svg';
+import { DocumentScale } from 'components/documents/document-scale/document-scale';
 
 type TDocumentToolbar = {
     countOfPages: number;
+    scale: number;
     onPageChange: (pageOrderNumber: number) => void;
+    onScaleChange: (value: SetStateAction<number>) => void;
 };
 
-export const DocumentToolbar: FC<TDocumentToolbar> = ({ countOfPages, onPageChange }) => {
+export const DocumentToolbar: FC<TDocumentToolbar> = ({
+    countOfPages,
+    scale,
+    onPageChange,
+    onScaleChange
+}) => {
     const { currentOrderPageNumber, pageNumbers, onCurrentPageChange } = useTaskAnnotatorContext();
     const isLastPage = currentOrderPageNumber === countOfPages - 1;
     const isFirstPage = currentOrderPageNumber === 0;
@@ -50,39 +58,42 @@ export const DocumentToolbar: FC<TDocumentToolbar> = ({ countOfPages, onPageChan
     }, [isFirstPage, currentOrderPageNumber, updateCurrentPage]);
 
     return (
-        <FlexRow cx={styles['goto-page-selector']}>
-            <FlexCell minWidth={68}>
-                <span>Current page</span>
-            </FlexCell>
-            <PickerInput
-                minBodyWidth={52}
-                size="24"
-                dataSource={pagesDataSource}
-                value={currentOrderPageNumber + 1}
-                onValueChange={onPickerValueChange}
-                getName={(item) => String(item)}
-                selectionMode="single"
-                disableClear={true}
-            />
-            <FlexRow>
-                <span>of {countOfPages}</span>
-                <Button
+        <>
+            <FlexRow cx={styles['goto-page-selector']}>
+                <FlexCell minWidth={68}>
+                    <span>Current page</span>
+                </FlexCell>
+                <PickerInput
+                    minBodyWidth={52}
                     size="24"
-                    fill="white"
-                    icon={goPrevIcon}
-                    cx={styles.button}
-                    onClick={handleGoPrev}
-                    isDisabled={isFirstPage}
+                    dataSource={pagesDataSource}
+                    value={currentOrderPageNumber + 1}
+                    onValueChange={onPickerValueChange}
+                    getName={(item) => String(item)}
+                    selectionMode="single"
+                    disableClear={true}
                 />
-                <Button
-                    size="24"
-                    fill="white"
-                    icon={goNextIcon}
-                    cx={styles.button}
-                    onClick={handleGoNext}
-                    isDisabled={isLastPage}
-                />
+                <FlexRow>
+                    <span>of {countOfPages}</span>
+                    <Button
+                        size="24"
+                        fill="white"
+                        icon={goPrevIcon}
+                        cx={styles.button}
+                        onClick={handleGoPrev}
+                        isDisabled={isFirstPage}
+                    />
+                    <Button
+                        size="24"
+                        fill="white"
+                        icon={goNextIcon}
+                        cx={styles.button}
+                        onClick={handleGoNext}
+                        isDisabled={isLastPage}
+                    />
+                </FlexRow>
             </FlexRow>
-        </FlexRow>
+            <DocumentScale scale={scale} onChange={onScaleChange} />
+        </>
     );
 };

--- a/web/src/shared/components/document-toolbar/index.tsx
+++ b/web/src/shared/components/document-toolbar/index.tsx
@@ -1,6 +1,6 @@
 import { FC, SetStateAction, useCallback } from 'react';
 import { FlexRow } from '@epam/uui-components';
-import { Button, FlexCell, PickerInput } from '@epam/loveship';
+import { Button, PickerInput } from '@epam/loveship';
 import styles from './styles.module.scss';
 import { useArrayDataSource } from '@epam/uui';
 import { useTaskAnnotatorContext } from 'connectors/task-annotator-connector/task-annotator-context';
@@ -60,9 +60,7 @@ export const DocumentToolbar: FC<TDocumentToolbar> = ({
     return (
         <>
             <FlexRow cx={styles['goto-page-selector']}>
-                <FlexCell minWidth={68}>
-                    <span>Current page</span>
-                </FlexCell>
+                <span>Current page</span>
                 <PickerInput
                     minBodyWidth={52}
                     size="24"

--- a/web/src/shared/components/document-toolbar/styles.module.scss
+++ b/web/src/shared/components/document-toolbar/styles.module.scss
@@ -1,0 +1,32 @@
+.goto-page-selector {
+    span {
+        font-size: 12px;
+    }
+
+    & > :nth-child(2) {
+        margin: 0 6px;
+        width: 72px;
+    }
+}
+
+.button {
+    align-items: center;
+    box-shadow: none !important;
+    width: 24px;
+    height: 24px;
+    align-self: center;
+
+    :global(.uui-caption) {
+        font-size: 24px;
+        padding: 0;
+    }
+
+    &:first-of-type {
+        margin-left: 12px;
+        margin-right: 3px;
+    }
+
+    &:last-of-type {
+        margin-right: 32px;
+    }
+}


### PR DESCRIPTION
In the scope of this PR, currently shown page's order number is in the dropdown when page is scrolled. "Go to page" is renamed to "Current page".