### PR TITLE
fix: save button tooltip

### DIFF
--- a/web/src/components/task/task-sidebar/task-sidebar.tsx
+++ b/web/src/components/task/task-sidebar/task-sidebar.tsx
@@ -342,7 +342,8 @@ const TaskSidebar: FC<TaskSidebarProps> = ({ jobSettings, viewMode, isNextTaskPr
 
     const saveButtonTooltipContent = getSaveButtonTooltipContent(
         isSaveButtonDisabled,
-        task?.status
+        task?.status,
+        isValidation
     );
 
     return (

--- a/web/src/components/task/task-sidebar/utils.ts
+++ b/web/src/components/task/task-sidebar/utils.ts
@@ -3,9 +3,12 @@ import { FINISHED_TASK_TOOLTIP_TEXT } from './finish-button/utils';
 
 export const getSaveButtonTooltipContent = (
     isSaveButtonDisabled: boolean,
-    taskStatus?: TaskStatus
+    taskStatus?: TaskStatus,
+    isValidation?: boolean
 ) => {
-    if (taskStatus === 'Finished') {
+    if (isValidation && taskStatus === 'In Progress') {
+        return 'Please validate some pages to enable "Save draft" button';
+    } else if (taskStatus === 'Finished') {
         return FINISHED_TASK_TOOLTIP_TEXT;
     } else if (taskStatus === 'Pending') {
         return null;


### PR DESCRIPTION
Second PR of SaveDraft button tooltip. Now, the isValidation argument is passed by the caller to the tooltip calculation function