### PR TITLE
fix: show skeleton-loader and spinner when they are needed

### DIFF
--- a/web/src/components/categories/categories-tab/categories-tab.tsx
+++ b/web/src/components/categories/categories-tab/categories-tab.tsx
@@ -47,7 +47,7 @@ export const CategoriesTab = ({ boundModeSwitch, setBoundModeSwitch }: Categorie
 
     const treeContainerRef = useRef<HTMLDivElement>(null);
 
-    const { categoryNodes, isFetched } = useCategoriesTree({
+    const { categoryNodes, isFetching } = useCategoriesTree({
         searchText,
         boundModeSwitch,
         jobId: getJobId()
@@ -122,13 +122,13 @@ export const CategoriesTab = ({ boundModeSwitch, setBoundModeSwitch }: Categorie
                 <CategoriesTree
                     key={searchText}
                     categoriesHeight={treeHeight}
-                    isLoading={!isFetched}
+                    isLoading={isFetching}
                     categoryNodes={categoryNodes}
                     onCategorySelected={onCategorySelected}
                     selectedHotKeys={selectedKeys}
                 />
             </div>
-            <Blocker isEnabled={!isFetched} />
+            <Blocker isEnabled={isFetching} />
         </div>
     );
 };

--- a/web/src/components/categories/categories-tree/use-categories-tree.tsx
+++ b/web/src/components/categories/categories-tree/use-categories-tree.tsx
@@ -41,7 +41,7 @@ export const useCategoriesTree = ({ searchText, boundModeSwitch, jobId }: Props)
 
     const {
         data: { pages: searchResult } = {},
-        isFetched,
+        isFetching,
         refetch
     } = useCategoriesByJob(
         {
@@ -64,5 +64,5 @@ export const useCategoriesTree = ({ searchText, boundModeSwitch, jobId }: Props)
         if (jobId) setCategoryNodes(mapCategories(searchResult));
     }, [searchResult, searchText, boundModeSwitch]);
 
-    return { categoryNodes, isFetched };
+    return { categoryNodes, isFetching };
 };

--- a/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
+++ b/web/src/connectors/task-annotator-connector/task-annotator-context.tsx
@@ -194,8 +194,8 @@ const defaultPageWidth: number = 0;
 const defaultPageHeight: number = 0;
 const defaultDocumentData = {
     latestAnnotationsResult: {
-        isFetching: true,
-        isLoading: true
+        isFetching: false,
+        isLoading: false
     } as UseQueryResult<AnnotationsResponse>,
     refetchLatestAnnotations: () => Promise.resolve(),
     latestAnnotationsResultData: undefined,


### PR DESCRIPTION
In the scope of this PR, the issue with showing UI spinners/skeleton loaders not in time is fixed.