### PR TITLE
fix: remove doc jumping when annotation is removed

### DIFF
--- a/web/src/shared/components/annotator/components/text-annotation/text-annotation.tsx
+++ b/web/src/shared/components/annotator/components/text-annotation/text-annotation.tsx
@@ -79,7 +79,8 @@ export const TextAnnotation = ({
                                             isEditable={isEditable}
                                             isSelected={isSelected}
                                             isHovered={isHovered}
-                                            onCloseIconClick={() => {
+                                            onCloseIconClick={(event) => {
+                                                event.stopPropagation();
                                                 onAnnotationDelete(annLabel.annotationId!);
                                             }}
                                             onContextMenu={(event) => {


### PR DESCRIPTION
In the scope of this PR, we remove "jump" effect when annotation is removed.