### PR TITLE
fix: blocking deletion of annotations in some scenarios.

### DIFF
--- a/web/src/components/task/task-sidebar-flow/__tests__/annotation.test.tsx
+++ b/web/src/components/task/task-sidebar-flow/__tests__/annotation.test.tsx
@@ -17,6 +17,7 @@ describe('AnnotationRow', () => {
         index: 15,
         onSelect: () => {},
         isEditable: false,
+        isClosable: true,
         onSelectById: () => {},
         onLinkDeleted: () => {},
         onCloseIconClick: () => {},

--- a/web/src/components/task/task-sidebar-flow/annotation-list.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotation-list.tsx
@@ -93,7 +93,7 @@ export const AnnotationList: FC<AnnotationListProps> = ({
     const isClosable =
         task?.status !== 'Finished'
             ? task?.is_validation
-                ? editedPages.includes(currentPage) !== false
+                ? editedPages.includes(currentPage)
                 : true
             : false;
 

--- a/web/src/components/task/task-sidebar-flow/annotation-list.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotation-list.tsx
@@ -76,12 +76,26 @@ export const AnnotationList: FC<AnnotationListProps> = ({
     const containerRef = useRef<HTMLDivElement>(null);
     const [selectedIndex, setSelectedIndex] = useState<number>(0);
     const [isSelectedInCurrentView, setIsSelectedInCurrentView] = useState<boolean>(false);
-    const { areLatestAnnotationsFetching, onLinkDeleted, onAnnotationDeleted, allAnnotations } =
-        useTaskAnnotatorContext();
+    const {
+        task,
+        areLatestAnnotationsFetching,
+        onLinkDeleted,
+        onAnnotationDeleted,
+        allAnnotations,
+        currentPage,
+        editedPages
+    } = useTaskAnnotatorContext();
     const { incomingLinksByAnnotationId, annotationNameById } = useMemo(
         () => collectIncomingLinks(list),
         [list]
     );
+
+    const isClosable =
+        task?.status !== 'Finished'
+            ? task?.is_validation
+                ? editedPages.includes(currentPage) !== false
+                : true
+            : false;
 
     useEffect(() => {
         if (!selectedAnnotation) {
@@ -193,6 +207,7 @@ export const AnnotationList: FC<AnnotationListProps> = ({
                             {...annotation}
                             index={index}
                             isEditable={isEditable}
+                            isClosable={isClosable}
                             key={`${annotation.id}-${index}`}
                             onLinkDeleted={onLinkDeleted}
                             annotationNameById={annotationNameById}

--- a/web/src/components/task/task-sidebar-flow/annotationRow.tsx
+++ b/web/src/components/task/task-sidebar-flow/annotationRow.tsx
@@ -28,6 +28,7 @@ export const AnnotationRow: FC<TAnnotationProps> = ({
     incomingLinks,
     links,
     isEditable,
+    isClosable,
     onLinkDeleted,
     onCloseIconClick
 }) => {
@@ -51,13 +52,15 @@ export const AnnotationRow: FC<TAnnotationProps> = ({
                 <Text cx={styles.labelText} rawProps={{ 'data-testid': 'flow-label' }}>
                     {labelList[labelList.length - 1]}
                 </Text>
-                <IconButton
-                    icon={closeIcon}
-                    cx={styles.close}
-                    iconPosition={'right'}
-                    onClick={onIconClick}
-                    color={isContrastColor(color) ? 'white' : 'night900'}
-                />
+                {isClosable && (
+                    <IconButton
+                        icon={closeIcon}
+                        cx={styles.close}
+                        iconPosition={'right'}
+                        onClick={onIconClick}
+                        color={isContrastColor(color) ? 'white' : 'night900'}
+                    />
+                )}
                 {!links?.length && !incomingLinks?.length ? null : (
                     <Links
                         isEditable={isEditable}

--- a/web/src/components/task/task-sidebar-flow/types.ts
+++ b/web/src/components/task/task-sidebar-flow/types.ts
@@ -9,6 +9,7 @@ export type TAnnotationProps = Annotation & {
     onSelectById: (id: Annotation['id']) => void;
     selectedAnnotationId?: Annotation['id'];
     isEditable: boolean;
+    isClosable: boolean;
     onLinkDeleted: (pageNum: number, annotationId: Annotation['id'], link: Link) => void;
     onCloseIconClick: (pageNum: number, annotationId: Annotation['id']) => void;
 };


### PR DESCRIPTION
If the task is in the finished status, and also during validation outside of page editing, the delete of annotations function becomes impossible.