### PR TITLE
feat: Post upload processing notifications

### DIFF
--- a/web/src/connectors/documents-page-control-connector/documents-page-control-connector.tsx
+++ b/web/src/connectors/documents-page-control-connector/documents-page-control-connector.tsx
@@ -47,7 +47,10 @@ export const DocumentsPageControlConnector = ({
     handleUploadWizardButtonClick
 }: DocumentsPageControlProps) => {
     const history = useHistory();
-    const uploadProgressTracker = useFetchWithTrackingOfUploadProgress();
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const uploadProgressTracker = useFetchWithTrackingOfUploadProgress({
+        onError: () => setIsLoading(false)
+    });
     const uploadFilesMutation = useUploadFilesMutationWithProgressTracking({
         customFetch: uploadProgressTracker.fetchWithTrackingOfUploadProgress
     });
@@ -58,7 +61,6 @@ export const DocumentsPageControlConnector = ({
         [isSearchPage]
     );
 
-    const [isLoading, setIsLoading] = useState<boolean>(false);
     const { notifyError, notifySuccess } = useNotifications();
 
     const {

--- a/web/src/connectors/documents-page-control-connector/fetch-with-tracking-of-upload-progress-factory.ts
+++ b/web/src/connectors/documents-page-control-connector/fetch-with-tracking-of-upload-progress-factory.ts
@@ -13,11 +13,11 @@ const handleUploadFailed = (xhr: XMLHttpRequest) => {
     });
 };
 
-export type TFetchType = ({
-    onProgressCallback
-}: {
+type WithOnProgressCallback = {
     onProgressCallback: UploadProgressTracker['setProgress'];
-}) => BadgerCustomFetch;
+};
+
+export type TFetchType = (args: WithOnProgressCallback) => BadgerCustomFetch;
 
 export const fetchWithTrackingOfUploadProgressFactory: TFetchType =
     ({ onProgressCallback }) =>

--- a/web/src/connectors/documents-page-control-connector/use-fetch-with-tracking-of-upload-progress.ts
+++ b/web/src/connectors/documents-page-control-connector/use-fetch-with-tracking-of-upload-progress.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { fetchWithTrackingOfUploadProgressFactory } from './fetch-with-tracking-of-upload-progress-factory';
 import { BadgerCustomFetch } from 'api/hooks/api';
 import { useNotifyProcessing } from './use-notify-processing';
-import { NotificationTypes, showNotification } from 'shared/components/notifications';
 
 export interface UploadProgressTracker {
     progress: number;
@@ -14,16 +13,6 @@ export interface UploadProgressTracker {
 
 type UseFetchWithTrackingOfUploadProgressDeps = {
     onError: () => void;
-};
-
-const useHandleUploadError = (onError: () => void) => {
-    return useCallback(() => {
-        showNotification({
-            type: NotificationTypes.error,
-            text: 'Error uploading the file. Try again later.'
-        });
-        onError();
-    }, [onError]);
 };
 
 export const useFetchWithTrackingOfUploadProgress = ({
@@ -39,15 +28,13 @@ export const useFetchWithTrackingOfUploadProgress = ({
         setProgress(0);
     }, []);
 
-    const handleError = useHandleUploadError(onError);
-
     const fetchWithTrackingOfUploadProgress: BadgerCustomFetch = useCallback(
         (url, reqParams) =>
             fetchWithTrackingOfUploadProgressFactory({
                 onProgressCallback: setProgress,
-                onError: handleError
+                onError
             })(url, reqParams),
-        [handleError]
+        [onError]
     );
 
     const uploadProgressTracker: UploadProgressTracker = useMemo(

--- a/web/src/connectors/documents-page-control-connector/use-fetch-with-tracking-of-upload-progress.ts
+++ b/web/src/connectors/documents-page-control-connector/use-fetch-with-tracking-of-upload-progress.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { fetchWithTrackingOfUploadProgressFactory } from './fetch-with-tracking-of-upload-progress-factory';
 import { BadgerCustomFetch } from 'api/hooks/api';
+import { useNotifyProcessing } from './use-notify-processing';
 export interface UploadProgressTracker {
     progress: number;
     setProgress: (progress: number) => void;
@@ -13,6 +14,8 @@ export const useFetchWithTrackingOfUploadProgress = (): UploadProgressTracker =>
     const [progress, setProgress] = useState<number>(0);
 
     const isUploaded = progress === 100;
+
+    useNotifyProcessing(isUploaded);
 
     const resetUploadProgressState = useCallback(() => {
         setProgress(0);

--- a/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
+++ b/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
@@ -11,28 +11,26 @@ const notifyProcessing = () => {
 export const useNotifyProcessing = (isUploaded: boolean) => {
     useEffect(() => {
         let delay = 10000;
-        let timeoutId: number | null = null;
+        let timeoutId: NodeJS.Timeout | null = null;
         let firstNotificationShown = false;
 
         const showNextNotification = () => {
-            if (isUploaded) {
-                if (!firstNotificationShown) {
-                    timeoutId = setTimeout(() => {
-                        firstNotificationShown = true;
-                        showNextNotification();
-                    }, delay) as unknown as number;
-                } else {
-                    notifyProcessing();
+            if (!isUploaded) return;
 
-                    delay *= 2;
-                    timeoutId = setTimeout(showNextNotification, delay) as unknown as number;
-                }
+            if (!firstNotificationShown) {
+                timeoutId = setTimeout(() => {
+                    firstNotificationShown = true;
+                    showNextNotification();
+                }, delay);
+            } else {
+                notifyProcessing();
+
+                delay *= 2;
+                timeoutId = setTimeout(showNextNotification, delay);
             }
         };
 
-        if (isUploaded) {
-            showNextNotification();
-        }
+        showNextNotification();
 
         return () => {
             if (timeoutId !== null) {

--- a/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
+++ b/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { NotificationTypes, showNotification } from 'shared/components/notifications';
+
+const notifyProcessing = () => {
+    showNotification({
+        type: NotificationTypes.hint,
+        text: 'Your file is still processing. This may take a while'
+    });
+};
+
+export const useNotifyProcessing = (isUploaded: boolean) => {
+    useEffect(() => {
+        let delay = 10000;
+        let timeoutId: number | null = null;
+        let firstNotificationShown = false;
+
+        const showNextNotification = () => {
+            if (isUploaded) {
+                if (!firstNotificationShown) {
+                    timeoutId = setTimeout(() => {
+                        firstNotificationShown = true;
+                        showNextNotification();
+                    }, delay) as unknown as number;
+                } else {
+                    notifyProcessing();
+
+                    delay *= 2;
+                    timeoutId = setTimeout(showNextNotification, delay) as unknown as number;
+                }
+            }
+        };
+
+        if (isUploaded) {
+            showNextNotification();
+        }
+
+        return () => {
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId);
+            }
+        };
+    }, [isUploaded]);
+};

--- a/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
+++ b/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
@@ -10,13 +10,13 @@ const notifyProcessing = () => {
 
 export const useNotifyProcessing = (isUploaded: boolean) => {
     useEffect(() => {
+        if (!isUploaded) return;
+
         let delay = 10000;
         let timeoutId: ReturnType<typeof setTimeout> | null = null;
         let firstNotificationShown = false;
 
         const showNextNotification = () => {
-            if (!isUploaded) return;
-
             if (!firstNotificationShown) {
                 timeoutId = setTimeout(() => {
                     firstNotificationShown = true;

--- a/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
+++ b/web/src/connectors/documents-page-control-connector/use-notify-processing.ts
@@ -11,7 +11,7 @@ const notifyProcessing = () => {
 export const useNotifyProcessing = (isUploaded: boolean) => {
     useEffect(() => {
         let delay = 10000;
-        let timeoutId: NodeJS.Timeout | null = null;
+        let timeoutId: ReturnType<typeof setTimeout> | null = null;
         let firstNotificationShown = false;
 
         const showNextNotification = () => {


### PR DESCRIPTION
The goal of this PR is to show notifications when file processing takes more than 10 seconds.

After first notification, next one will be in 20sec and on every time notification is shown, delay is doubled.

For that was implemented `useNotifyProcessing` hook, which will watch `isUploadedValue` from `useFetchWithTrackingOfUploadProgress` and trigger the notifications based on that.