### PR TITLE
test(annotation): cover create_tasks

### DIFF
--- a/annotation/tests/test_distribution.py
+++ b/annotation/tests/test_distribution.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from uuid import UUID
 
 import pytest
+from tests.override_app_dependency import TEST_TENANT
 
 from annotation.distribution import (
     add_unassigned_file,
@@ -38,7 +39,6 @@ from annotation.schemas import (
     TaskStatusEnumSchema,
     ValidationSchema,
 )
-from tests.override_app_dependency import TEST_TENANT
 
 JOB_ID = 1
 ANNOTATORS = [

--- a/annotation/tests/test_distribution.py
+++ b/annotation/tests/test_distribution.py
@@ -1555,23 +1555,25 @@ def test_create_tasks(
     expected_pages_number: int,
 ):
     user = {"user_id": 0, "pages_number": 30}
-    files = [
-        {
-            "file_id": 0,
-            "unassigned_pages": list(unassigned_pages),
-            "pages_number": len(unassigned_pages),
-        }
-    ]
     tasks = []
-    job_id = 10
-    is_validation = False
-    status = TaskStatusEnumSchema.pending
-
     with patch(
         "annotation.distribution.main.SPLIT_MULTIPAGE_DOC",
         True,
     ), patch("annotation.distribution.main.MAX_PAGES", 10):
-        create_tasks(tasks, files, user, job_id, is_validation, status)
+        create_tasks(
+            tasks,
+            [
+                {
+                    "file_id": 0,
+                    "unassigned_pages": list(unassigned_pages),
+                    "pages_number": len(unassigned_pages),
+                }
+            ],
+            user,
+            10,
+            False,
+            TaskStatusEnumSchema.pending,
+        )
         assert [task["pages"] for task in tasks] == [
             list(pages) for pages in expected_task_pages
         ]


### PR DESCRIPTION
This pr contains tests for testing the function _create_tasks_ in the file /tests/test_distribution.py. 

The test covers two cases of the functions use. First case is when the amount of pages to assign is less than the MAX_PAGES attribute and the second case covers when the files have to be split to multiple tasks.