### PR TITLE
feat: revision based jobs

### DIFF
--- a/annotation/annotation/annotations/main.py
+++ b/annotation/annotation/annotations/main.py
@@ -1019,3 +1019,15 @@ def construct_document_links(
             )
         )
     return links
+
+
+def get_annotations_by_revision(
+    revisions: Set[str], db: Session
+) -> List[AnnotatedDoc]:
+    if not revisions:
+        return []
+    return (
+        db.query(AnnotatedDoc)
+        .filter(AnnotatedDoc.revision.in_(revisions))
+        .all()
+    )

--- a/annotation/annotation/annotations/resources.py
+++ b/annotation/annotation/annotations/resources.py
@@ -88,8 +88,8 @@ async def get_annotations(
     filter_args = filter_lib.map_request_to_filter(
         request.dict(), AnnotatedDoc.__name__
     )
-    # TODO: distinct on revision, fix filter_lib to work with
-    #  distinct and sorting
+    # Distinct on revision, filter_lib doesn't work right with
+    # distinct and sorting
     subquery = (
         db.query(AnnotatedDoc)
         .filter(AnnotatedDoc.tenant == x_current_tenant)

--- a/annotation/annotation/filters.py
+++ b/annotation/annotation/filters.py
@@ -31,3 +31,5 @@ TaskFilter = create_filter_model(
     ],
     include=ADDITIONAL_TASK_FIELDS,
 )
+
+AnnotationRequestFilter = create_filter_model(AnnotatedDoc)

--- a/annotation/annotation/schemas/jobs.py
+++ b/annotation/annotation/schemas/jobs.py
@@ -68,6 +68,13 @@ class JobInfoSchema(BaseModel):
     )
     files: Set[int] = Field(..., example={1, 2, 3})
     datasets: Set[int] = Field(..., example={1, 2, 3})
+    revisions: Set[str] = Field(
+        set(),
+        example={
+            "35b7b50a056d00048b0977b195f7f8e9f9f7400f",
+            "4dc503a9ade7d7cb55d6be671748a312d663bb0a",
+        },
+    )
     previous_jobs: List[PreviousJobInfoSchema] = Field(...)
     is_auto_distribution: bool = Field(default=False, example=False)
     categories: Optional[Set[str]] = Field(None, example={"1", "2"})
@@ -83,20 +90,21 @@ class JobInfoSchema(BaseModel):
     @root_validator
     def check_files_datasets_previous_jobs(cls, values):
         """
-        Files and datasets should not be empty at the same time.
+        Files and datasets and revisions should not be empty at the same time.
         """
         files, datasets = values.get("files"), values.get("datasets")
+        revisions = values.get("revisions")
         previous_jobs = values.get("previous_jobs")
 
         job_type = values.get("job_type")
 
         if (
-            not (bool(previous_jobs) ^ bool(files or datasets))
+            not (bool(previous_jobs) ^ bool(files or datasets or revisions))
             and job_type != JobTypeEnumSchema.ImportJob
         ):
             raise ValueError(
                 "Only one field must be specified: "
-                "either previous_jobs or files/datasets"
+                "either previous_jobs or files/datasets/revisions"
             )
         return values
 

--- a/jobs/alembic/versions/a4b7b64a472c_add_revisions_field_to_job.py
+++ b/jobs/alembic/versions/a4b7b64a472c_add_revisions_field_to_job.py
@@ -1,0 +1,32 @@
+"""add revisions field to job
+
+Revision ID: a4b7b64a472c
+Revises: 2dd22b64e1a9
+Create Date: 2024-09-11 17:40:41.052573
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a4b7b64a472c"
+down_revision = "2dd22b64e1a9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "job",
+        sa.Column(
+            "revisions",
+            sa.ARRAY(sa.String(50)),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("job", "revisions")

--- a/jobs/jobs/airflow_utils.py
+++ b/jobs/jobs/airflow_utils.py
@@ -66,6 +66,7 @@ async def run(
     files: List[pipeline.PipelineFile],
     current_tenant: str,
     datasets: List[pipeline.Dataset],
+    revisions: List[str],
 ) -> None:
     configuration = get_configuration()
     with client.ApiClient(configuration) as api_client:
@@ -79,6 +80,7 @@ async def run(
                     tenant=current_tenant,
                     files_data=files,
                     datasets=datasets,
+                    revisions=revisions,
                 )
             ),
         )
@@ -97,5 +99,8 @@ class AirflowPipeline(pipeline.BasePipeline):
         files: List[pipeline.PipelineFile],
         current_tenant: str,
         datasets: List[pipeline.Dataset],
+        revisions: List[str],
     ) -> None:
-        return await run(pipeline_id, job_id, files, current_tenant, datasets)
+        return await run(
+            pipeline_id, job_id, files, current_tenant, datasets, revisions
+        )

--- a/jobs/jobs/create_job_funcs.py
+++ b/jobs/jobs/create_job_funcs.py
@@ -41,39 +41,17 @@ async def get_all_datasets_and_files_data(
     return files_data, valid_dataset_tags, valid_separate_files_uuids
 
 
-# noinspection PyUnreachableCode
 async def create_extraction_job(
-    extraction_job_input: ExtractionJobParams,
+    extraction_job_input: ExtractionJobParams,  # todo: should be JobParams
     current_tenant: str,
     jw_token: str,
     db: Session = Depends(db_service.get_session),
 ) -> dbm.CombinedJob:
     """Creates new ExtractionJob and saves it in the database"""
-
-    if False:
-        # old pipelines service
-        pipeline_instance = await utils.get_pipeline_instance_by_its_name(
-            pipeline_name=extraction_job_input.pipeline_name,
-            current_tenant=current_tenant,
-            jw_token=jw_token,
-            pipeline_version=extraction_job_input.pipeline_version,
-        )
-
-        pipeline_id = (
-            extraction_job_input.pipeline_name
-            if extraction_job_input.pipeline_name.endswith(":airflow")
-            else pipeline_instance.get("id")
-        )
-
-        pipeline_categories = pipeline_instance.get("meta", {}).get(
-            "categories", []
-        )
-
-    else:
-        pipeline_id = extraction_job_input.pipeline_id
-        pipeline_engine = extraction_job_input.pipeline_engine
-        # check if categories passed and then append all categories to job
-        pipeline_categories = []
+    pipeline_id = extraction_job_input.pipeline_id
+    pipeline_engine = extraction_job_input.pipeline_engine
+    # check if categories passed and then append all categories to job
+    pipeline_categories = []
 
     (
         files_data,
@@ -119,6 +97,7 @@ async def create_extraction_job(
         extraction_job_input.previous_jobs,
         initial_status,
         pipeline_categories,
+        list(extraction_job_input.revisions),
     )
 
     return job_in_db
@@ -150,28 +129,10 @@ async def create_extraction_annotation_job(
     db: Session = Depends(db_service.get_session),
 ) -> dbm.CombinedJob:
     """Creates new ExtractionWithAnnotationJob and saves it in the database"""
-    if False:
-        pipeline_instance = await utils.get_pipeline_instance_by_its_name(
-            pipeline_name=extraction_annotation_job_input.pipeline_name,
-            current_tenant=current_tenant,
-            jw_token=jw_token,
-            pipeline_version=extraction_annotation_job_input.pipeline_version,
-        )
-        pipeline_id = (
-            extraction_annotation_job_input.pipeline_name
-            if extraction_annotation_job_input.pipeline_name.endswith(
-                ":airflow"
-            )
-            else pipeline_instance.get("id")
-        )
-        pipeline_categories = pipeline_instance.get("meta", {}).get(
-            "categories", []
-        )
-    else:
-        pipeline_id = extraction_annotation_job_input.pipeline_id
-        pipeline_engine = extraction_annotation_job_input.pipeline_engine
-        # check if categories passed and then append all categories to job
-        pipeline_categories = []
+    pipeline_id = extraction_annotation_job_input.pipeline_id
+    pipeline_engine = extraction_annotation_job_input.pipeline_engine
+    # check if categories passed and then append all categories to job
+    pipeline_categories = []
 
     (
         files_data,

--- a/jobs/jobs/databricks_utils.py
+++ b/jobs/jobs/databricks_utils.py
@@ -46,6 +46,7 @@ async def run(
     files: List[pipeline.PipelineFile],
     current_tenant: str,
     datasets: List[pipeline.Dataset],
+    revisions: List[str],
 ) -> None:
     logger.info(
         "Running pipeline %s, job_id %s, current_tenant: %s with arguments %s",
@@ -65,6 +66,7 @@ async def run(
                         tenant=current_tenant,
                         files_data=files,
                         datasets=datasets,
+                        revisions=revisions,
                     )
                 )
             )
@@ -84,7 +86,13 @@ class DatabricksPipeline(pipeline.BasePipeline):
         files: List[pipeline.PipelineFile],
         current_tenant: str,
         datasets: List[pipeline.Dataset],
+        revisions: List[str],
     ) -> None:
         await run(
-            pipeline_id, int(job_id), files, current_tenant, datasets=datasets
+            pipeline_id,
+            int(job_id),
+            files,
+            current_tenant,
+            datasets=datasets,
+            revisions=revisions,
         )

--- a/jobs/jobs/db_service.py
+++ b/jobs/jobs/db_service.py
@@ -32,6 +32,7 @@ def create_extraction_job(
     previous_jobs: List[int],
     status: schemas.Status,
     categories: List[str],
+    revisions: List[str],
 ) -> dbm.CombinedJob:
     """Creates new ExtractionJob in the database"""
     job_row = dbm.CombinedJob(
@@ -49,6 +50,7 @@ def create_extraction_job(
         pipeline_engine=pipeline_engine,
         creation_datetime=datetime.utcnow(),
         categories=categories,
+        revisions=revisions or [],
     )
     db.add(job_row)
     db.commit()
@@ -79,6 +81,7 @@ def create_annotation_job(
         extensive_coverage=annotation_job_input.extensive_coverage,
         available_annotation_types=annotation_job_input.available_annotation_types,  # noqa: E501
         available_link_types=annotation_job_input.available_link_types,
+        revisions=list(annotation_job_input.revisions),
     )
     db.add(job_row)
     db.commit()
@@ -123,6 +126,7 @@ def create_extraction_annotation_job(
         all_files_data=all_files_data,
         start_manual_job_automatically=extraction_annotation_job_input.start_manual_job_automatically,  # noqa: E501
         extensive_coverage=extraction_annotation_job_input.extensive_coverage,  # noqa: E501
+        revisions=list(extraction_annotation_job_input.revisions),
     )
     db.add(job_row)
     db.commit()

--- a/jobs/jobs/models.py
+++ b/jobs/jobs/models.py
@@ -1,7 +1,15 @@
 from typing import Any, Dict, List
 
 from filter_lib import create_filter_model
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, inspect
+from sqlalchemy import (
+    ARRAY,
+    Boolean,
+    Column,
+    DateTime,
+    Integer,
+    String,
+    inspect,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -22,6 +30,7 @@ class Job(Base):  # type: ignore
     files = Column(JSONB)
     datasets = Column(JSONB)
     previous_jobs = Column(JSONB)
+    revisions = Column(ARRAY(String(50)), nullable=False)
     creation_datetime = Column(DateTime)
     type = Column(String(30))
     mode = Column(String(30))

--- a/jobs/jobs/pipeline.py
+++ b/jobs/jobs/pipeline.py
@@ -31,6 +31,7 @@ class PipelineRunArgs:
     tenant: str
     files_data: List[PipelineFile]
     datasets: List[Dataset]
+    revisions: List[str]
 
 
 @dataclass

--- a/jobs/jobs/run_job_funcs.py
+++ b/jobs/jobs/run_job_funcs.py
@@ -63,6 +63,7 @@ async def run_extraction_job(
         files_data=converted_files_data,
         current_tenant=current_tenant,
         datasets=datasets,
+        revisions=job_to_run.revisions,
     )
 
     return None

--- a/jobs/jobs/schemas.py
+++ b/jobs/jobs/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from pydantic import BaseModel, Field, validator
 from pydantic.fields import ModelField
@@ -41,6 +41,7 @@ class ExtractionJobParams(BaseModel):
     files: List[int] = []
     datasets: List[int] = []
     previous_jobs: Optional[List[int]] = []
+    revisions: Set[str] = set()
     pipeline_name: str
     pipeline_version: Optional[str]
     pipeline_engine: Optional[str]
@@ -66,6 +67,7 @@ class AnnotationJobParams(BaseModel):
     files: Optional[List[int]] = []
     datasets: Optional[List[int]] = []
     previous_jobs: Optional[List[int]] = []
+    revisions: Set[str] = set()
     annotators: List[str]
     validators: List[str]
     owners: List[str]
@@ -108,6 +110,7 @@ class JobParams(BaseModel):
     type: JobType
     files: Optional[List[int]] = []
     datasets: Optional[List[int]] = []
+    revisions: Set[str] = set()
     previous_jobs: Optional[List[int]] = []
     is_draft: bool = False
     # ---- AnnotationJob and ExtractionWithAnnotationJob attributes ---- #
@@ -140,10 +143,10 @@ class JobParams(BaseModel):
         if values.get("type") != JobType.ImportJob:
             files = values.get("files")
             datasets = values.get("datasets")
-
-            assert bool(v) ^ bool(files or datasets), (
+            revisions = values.get("revisions")
+            assert bool(v) ^ bool(files or datasets or revisions), (
                 "Only one field must be specified: "
-                "either previous_jobs or files/datasets"
+                "either previous_jobs or files/datasets/revisions"
             )
 
         return v

--- a/jobs/jobs/utils.py
+++ b/jobs/jobs/utils.py
@@ -335,6 +335,7 @@ async def execute_external_pipeline(
     files_data: List[Dict[str, Any]],
     current_tenant: str,
     datasets: List[Dict],
+    revisions: List[str],
 ) -> None:
     logger.info("Running pipeline_engine %s", pipeline_engine)
     kwargs = {
@@ -345,6 +346,7 @@ async def execute_external_pipeline(
         ),
         "current_tenant": current_tenant,
         "datasets": datasets,
+        "revisions": revisions,
     }
     logger.info("Pipeline params: %s", kwargs)
     if pipeline_engine == "airflow":
@@ -432,6 +434,7 @@ async def execute_in_annotation_microservice(
         "categories": created_job.categories,
         "deadline": fastapi.encoders.jsonable_encoder(created_job.deadline),
         "extensive_coverage": created_job.extensive_coverage,
+        "revisions": created_job.revisions,
     }
     if created_job.validation_type:
         json["validation_type"] = created_job.validation_type

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -1174,13 +1174,14 @@ async def test_execute_external_pipeline(sign_s3_links: bool):
                     "bucket": "test",
                     "file": f"files/1/1.{sign_s3_links}.pdf",
                     "pages": [1, 2, 3],
-                    "output_path": f"runs/1/1",
+                    "output_path": "runs/1/1",
                     "datasets": ["dataset11"],
                 }
             ],
             previous_jobs_data=[],
             current_tenant="test_tenant",
             datasets=[{"id": 1, "name": "dataset11"}],
+            revisions=[],
         )
 
         assert FakePipeline.calls


### PR DESCRIPTION
- [x] Add `revisions` field to schemas and models
- [x] Create alembic migration
- [x] Update `POST /jobs/create_job` endpoint
- [x] Copy revision annotations over to the new job when got request from jobs on annotation side `annotation/jobs/{job_id}`
- [ ] ~~?? Update `PUT /jobs/{job_id}` endpoint~~
- [x] Update `POST /start/{job_id}` endpoint
- [x] Test with UI
- [x] Groom the code
- [ ] ~~Add tests~~
- [x] [STEP 2] Add endpoint to retrieve annotations with unique revisions
