### PR TITLE
fix: cannot create job if validation type is changed from extensive to others in web ui

### DIFF
--- a/web/src/connectors/edit-job-connector/edit-job-connector.tsx
+++ b/web/src/connectors/edit-job-connector/edit-job-connector.tsx
@@ -275,6 +275,10 @@ const EditJobConnector: FC<EditJobConnectorProps> = ({
                 delete jobProps.start_manual_job_automatically;
             }
 
+            if (jobProps.extensive_coverage && validationType !== ValidationType.extensiveCoverage) {
+                delete jobProps.extensive_coverage
+            }
+
             if (selected_taxonomies) {
                 jobProps.categories = jobProps.categories?.map((categoryId) => {
                     const currentTaxonomy = selected_taxonomies[categoryId as string | number];


### PR DESCRIPTION
- remove extensive_coverage value if validation type is not coverage

closes: #999 