### PR TITLE
#785 - User has to select a file twice

### DIFF
--- a/web/src/connectors/edit-job-connector/edit-job-connector.tsx
+++ b/web/src/connectors/edit-job-connector/edit-job-connector.tsx
@@ -275,8 +275,11 @@ const EditJobConnector: FC<EditJobConnectorProps> = ({
                 delete jobProps.start_manual_job_automatically;
             }
 
-            if (jobProps.extensive_coverage && validationType !== ValidationType.extensiveCoverage) {
-                delete jobProps.extensive_coverage
+            if (
+                jobProps.extensive_coverage &&
+                validationType !== ValidationType.extensiveCoverage
+            ) {
+                delete jobProps.extensive_coverage;
             }
 
             if (selected_taxonomies) {

--- a/web/src/connectors/jobs-table-connector/jobs-table-connector.tsx
+++ b/web/src/connectors/jobs-table-connector/jobs-table-connector.tsx
@@ -105,7 +105,23 @@ export const JobsTableConnector: FC<JobsTableConnectorProps> = ({
             const filtersToSet = prepareFiltersToSet<Job, unknown>(tableValue);
             saveFiltersToStorage(filtersToSet, 'jobs');
 
-            setFilters(filtersToSet);
+            setFilters(
+                filtersToSet.map((filter) =>
+                    filter
+                        ? {
+                              ...filter,
+                              value: filter.value as
+                                  | string
+                                  | number
+                                  | boolean
+                                  | number[]
+                                  | string[]
+                                  | boolean[]
+                                  | undefined
+                          }
+                        : filter
+                )
+            );
         }
     }, [tableValue.filter]);
 
@@ -305,7 +321,11 @@ export const JobsTableConnector: FC<JobsTableConnectorProps> = ({
                 </Panel>
 
                 {shownPopup ? (
-                    <JobPopup popupType={shownPopup} closePopup={() => shownPopupChange(null)} />
+                    <JobPopup
+                        popupType={shownPopup}
+                        closePopup={() => shownPopupChange(null)}
+                        selectedFiles={selectedFiles}
+                    />
                 ) : null}
             </Panel>
         );

--- a/web/src/pages/document/document-page-sidebar-content/document-page-sidebar-content.tsx
+++ b/web/src/pages/document/document-page-sidebar-content/document-page-sidebar-content.tsx
@@ -101,7 +101,10 @@ export const DocumentPageSidebarContent = ({
                         <Button
                             cx={styles['add-job']}
                             onClick={() =>
-                                onAddJob(documentJobRevisionsInfo.selectedDocumentJobRevisionId, fileMetaInfo.id)
+                                onAddJob(
+                                    documentJobRevisionsInfo.selectedDocumentJobRevisionId,
+                                    fileMetaInfo.id
+                                )
                             }
                             caption="New job from revision"
                         />

--- a/web/src/pages/documents/documents-page.tsx
+++ b/web/src/pages/documents/documents-page.tsx
@@ -26,50 +26,52 @@ const DocumentsPage = () => {
     const { path } = useRouteMatch();
 
     const [activeDataset, setActiveDataset] = useState<Dataset | null | undefined>(null);
-    const [fileIds, setFileIds] = useState<Array<number>>([]);
-
+    const [selectedFiles, setSelectedFiles] = useState<number[]>([]);
     const [isFileOver, setFileOver] = useState<boolean>(false);
 
-    const onFileSelect = useCallback((ids) => {
-        setFileIds(ids);
+    const onFilesSelect = useCallback((ids: number[]) => {
+        setSelectedFiles(ids);
     }, []);
 
     const handleUploadWizardButtonClick = useCallback(() => {
         history.push(`${path}/upload-wizard`);
-    }, []);
+    }, [history, path]);
 
     const onSearchClick = useCallback(() => {
         history.push(`${path}/search`);
-    }, []);
+    }, [history, path]);
 
     const handleDatasetSelected = (dataset?: Dataset | null) => {
         setActiveDataset(dataset);
+        setSelectedFiles([]); // Reset selection when dataset changes
         return history.push(`${path}`);
     };
 
-    const handleJobAddClick = () => {
+    const handleJobAddClick = useCallback(() => {
+        if (selectedFiles.length === 0) {
+            console.warn('No files selected for job addition');
+        }
         return history.push({
             pathname: `${JOBS_PAGE}/add`,
-            state: {
-                files: fileIds
-            }
+            state: { files: selectedFiles }
         });
-    };
+    }, [selectedFiles, history]);
 
-    const handleRowClick = (id: number) =>
-        history.push({
-            pathname: `${path}/${id}`
-        });
+    const handleRowClick = useCallback(
+        (id: number) =>
+            history.push({
+                pathname: `${path}/${id}`
+            }),
+        [history, path]
+    );
 
-    const rowRender = (dataset: Dataset) => {
-        return (
-            <DatasetRow
-                dataset={dataset}
-                onDatasetClick={handleDatasetSelected}
-                activeDataset={activeDataset}
-            />
-        );
-    };
+    const rowRender = (dataset: Dataset) => (
+        <DatasetRow
+            dataset={dataset}
+            onDatasetClick={handleDatasetSelected}
+            activeDataset={activeDataset}
+        />
+    );
 
     const renderCreateBtn: RenderCreateBtn = ({ onCreated }) => (
         <AddDatasetConnector onCreated={onCreated} />
@@ -109,8 +111,8 @@ const DocumentsPage = () => {
                                         <DocumentsTableConnector
                                             dataset={activeDataset}
                                             onRowClick={handleRowClick}
-                                            fileIds={fileIds}
-                                            onFilesSelect={onFileSelect}
+                                            onFilesSelect={onFilesSelect}
+                                            checkedValues={selectedFiles}
                                             handleJobAddClick={handleJobAddClick}
                                             withHeader
                                         />
@@ -144,7 +146,7 @@ const DocumentsPage = () => {
                             >
                                 <DocumentsDropZone dataset={activeDataset}>
                                     {!isFileOver && (
-                                        <DocumentsCardConnector onFilesSelect={onFileSelect} />
+                                        <DocumentsCardConnector onFilesSelect={onFilesSelect} />
                                     )}
                                 </DocumentsDropZone>
                             </div>

--- a/web/src/pages/jobs/job-popup.tsx
+++ b/web/src/pages/jobs/job-popup.tsx
@@ -1,18 +1,27 @@
 import styles from './job-popup.module.scss';
 import { Button, Checkbox, IconContainer, SearchInput, TextInput } from '@epam/loveship';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ReactComponent as closeIcon } from '@epam/assets/icons/common/navigation-close-24.svg';
 
 interface JobPopupProps {
     popupType: 'extraction' | 'annotation' | null;
     closePopup: () => void;
+    selectedFiles: number[];
 }
 
-const JobPopup: React.FC<JobPopupProps> = ({ popupType, closePopup }) => {
+const JobPopup: React.FC<JobPopupProps> = ({ popupType, closePopup, selectedFiles }) => {
     const [searchDataset, searchDatasetChange] = useState<string>('');
     const [searchPipeline, searchPipelineChange] = useState<string>('');
     const [hasOnlySelectedDoc, hasOnlySelectedDocChange] = useState<boolean>(false);
     const [validators, validatorsChange] = useState<string | undefined>('1');
+
+    useEffect(() => {
+        if (selectedFiles && selectedFiles.length > 0) {
+            hasOnlySelectedDocChange(true);
+        } else {
+            hasOnlySelectedDocChange(false);
+        }
+    }, [selectedFiles]);
 
     return (
         <>


### PR DESCRIPTION
Go to BadgerDoc platform -> "Documents" tab
Select a check box for some files (or one file)
Press "+Add to extraction"
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/b9fb57d1-0e86-46df-bb0a-76bfdb7c26da" />

Expected result:
The file selected on "Documents" tab is selected on the "Datasets" page
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/52ad15ca-03e6-4fc9-b96c-fbdbe5c96417" />

Key changes:

- Updated the DocumentsTableConnector logic to ensure that file selections are stored in the parent state and passed correctly to the "Datasets" page.

- Fixed the "Select All" behavior to prevent infinite loops and ensure clean, bulk selection handling.

- Optimized useEffect hooks to synchronize selection and prevent redundant updates.
