### PR TITLE
fix: persist file selection when adding to extraction (#785) 

### DIFF
--- a/web/src/connectors/documents-table-connector/documents-table-connector.tsx
+++ b/web/src/connectors/documents-table-connector/documents-table-connector.tsx
@@ -60,7 +60,6 @@ export const DocumentsTableConnector: React.FC<DocumentsTableConnectorProps> = (
     onRowClick,
     onFilesSelect,
     fileIds,
-    checkedValues,
     isJobPage,
     handleJobAddClick,
     withHeader

--- a/web/src/connectors/documents-table-connector/documents-table-connector.tsx
+++ b/web/src/connectors/documents-table-connector/documents-table-connector.tsx
@@ -94,10 +94,10 @@ export const DocumentsTableConnector: React.FC<DocumentsTableConnectorProps> = (
     const [jobs, setJobs] = useState<FileJobs>();
 
     useEffect(() => {
-        if (checkedValues) {
+        if (fileIds) {
             onTableValueChange({
                 ...tableValue,
-                checked: checkedValues
+                checked: fileIds
             });
         }
     }, []);
@@ -128,20 +128,20 @@ export const DocumentsTableConnector: React.FC<DocumentsTableConnectorProps> = (
             filtersToSet = filters.flatMap((item) => {
                 const field = item as keyof FileDocument;
                 const filter = tableValue.filter![field as keyof FileDocument];
-                const operator = Object.keys(
-                    tableValue.filter![field as keyof FileDocument]!
-                )[0] as Operators;
                 const operatorsArray = Object.keys(filter!);
                 if (operatorsArray.length === 1) {
-                    return {
-                        field,
-                        operator: operatorsArray[0] as Operators,
-                        value: filter![operator]! as string[]
-                    };
+                    const operator = operatorsArray[0] as Operators;
+                    return [
+                        {
+                            field,
+                            operator,
+                            value: filter![operator]! as string[]
+                        }
+                    ];
                 } else if ('from' in filter! && 'to' in filter) {
                     return [
-                        { field, operator: Operators.GE, value: filter['from'] },
-                        { field, operator: Operators.LE, value: filter['to'] }
+                        { field, operator: Operators.GE, value: filter['from'] as string[] },
+                        { field, operator: Operators.LE, value: filter['to'] as string[] }
                     ];
                 } else {
                     return [];

--- a/web/src/connectors/edit-job-connector/edit-job-connector.tsx
+++ b/web/src/connectors/edit-job-connector/edit-job-connector.tsx
@@ -275,8 +275,11 @@ const EditJobConnector: FC<EditJobConnectorProps> = ({
                 delete jobProps.start_manual_job_automatically;
             }
 
-            if (jobProps.extensive_coverage && validationType !== ValidationType.extensiveCoverage) {
-                delete jobProps.extensive_coverage
+            if (
+                jobProps.extensive_coverage &&
+                validationType !== ValidationType.extensiveCoverage
+            ) {
+                delete jobProps.extensive_coverage;
             }
 
             if (selected_taxonomies) {

--- a/web/src/pages/document/document-page-sidebar-content/document-page-sidebar-content.tsx
+++ b/web/src/pages/document/document-page-sidebar-content/document-page-sidebar-content.tsx
@@ -101,7 +101,10 @@ export const DocumentPageSidebarContent = ({
                         <Button
                             cx={styles['add-job']}
                             onClick={() =>
-                                onAddJob(documentJobRevisionsInfo.selectedDocumentJobRevisionId, fileMetaInfo.id)
+                                onAddJob(
+                                    documentJobRevisionsInfo.selectedDocumentJobRevisionId,
+                                    fileMetaInfo.id
+                                )
                             }
                             caption="New job from revision"
                         />

--- a/web/src/pages/jobs/edit-job-page.tsx
+++ b/web/src/pages/jobs/edit-job-page.tsx
@@ -20,11 +20,14 @@ import styles from '../../shared/components/wizard/wizard/wizard.module.scss';
 import pageStyles from './edit-job-page.module.scss';
 import { RevisionsTableConnector } from 'connectors/revisions-table-connector';
 
+interface LocationState {
+    files?: number[];
+}
+
 export const EditJobPage = () => {
     const history = useHistory();
     const location = useLocation();
-
-    const fileIds = (location.state as any)?.files || [];
+    const fileIds = (location.state as LocationState)?.files || [];
     const { jobId } = useParams() as { jobId: string };
 
     const [files, setFiles] = useState<number[]>([]);

--- a/web/src/pages/jobs/edit-job-page.tsx
+++ b/web/src/pages/jobs/edit-job-page.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useEffect, useState } from 'react';
 
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, useLocation } from 'react-router-dom';
 import { Button, MultiSwitch } from '@epam/loveship';
 import Wizard, {
     renderWizardButtons,
@@ -22,6 +22,9 @@ import { RevisionsTableConnector } from 'connectors/revisions-table-connector';
 
 export const EditJobPage = () => {
     const history = useHistory();
+    const location = useLocation();
+
+    const fileIds = (location.state as any)?.files || [];
     const { jobId } = useParams() as { jobId: string };
 
     const [files, setFiles] = useState<number[]>([]);
@@ -99,6 +102,7 @@ export const EditJobPage = () => {
             <DocumentsTableConnector
                 isJobPage
                 onFilesSelect={setFiles}
+                fileIds={fileIds}
                 onRowClick={() => null}
                 checkedValues={files}
             />


### PR DESCRIPTION
Go to BadgerDoc platform -> "Documents" tab
Select a check box for some files (or one file)
Press "+Add to extraction"
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/b9fb57d1-0e86-46df-bb0a-76bfdb7c26da" />

Expected result:
The file selected on "Documents" tab is selected on the "Datasets" page
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/52ad15ca-03e6-4fc9-b96c-fbdbe5c96417" />

Key changes:

- Updated useEffect to initialize selected files using `fileIds` from the location state.
- Added `fileIds` prop to `DocumentsTableConnector` for transferring file selection from previous actions.
- Ensured file selections persist when navigating between "Documents" and other pages.