### PR TITLE
feat: enable enter key navigation in page picker

### DIFF
--- a/web/src/shared/components/document-toolbar/index.tsx
+++ b/web/src/shared/components/document-toolbar/index.tsx
@@ -34,10 +34,11 @@ export const DocumentToolbar: FC<TDocumentToolbar> = ({
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
             const pageNumber = parseInt(pageInputValue, 10);
-            if (!isNaN(pageNumber)) {
-                const validPage = Math.min(Math.max(1, pageNumber), countOfPages);
-                onPickerValueChange(validPage);
-                setPageInputValue(String(validPage));
+            if (!isNaN(pageNumber) && pageNumber >= 1 && pageNumber <= countOfPages) {
+                onPickerValueChange(pageNumber);
+                setPageInputValue(String(pageNumber));
+            } else {
+                setPageInputValue(String(currentOrderPageNumber + 1));
             }
         }
     };
@@ -94,7 +95,6 @@ export const DocumentToolbar: FC<TDocumentToolbar> = ({
                     valueType="id"
                     rawProps={{
                         input: {
-                            defaultValue: pageInputValue,
                             onChange: handlePageInputChange,
                             onKeyDown: handleKeyDown
                         }

--- a/web/src/shared/components/document-toolbar/index.tsx
+++ b/web/src/shared/components/document-toolbar/index.tsx
@@ -1,4 +1,4 @@
-import { FC, SetStateAction, useCallback } from 'react';
+import { FC, SetStateAction, useCallback, useEffect, useState } from 'react';
 import { FlexRow } from '@epam/uui-components';
 import { Button, PickerInput } from '@epam/loveship';
 import styles from './styles.module.scss';
@@ -25,6 +25,26 @@ export const DocumentToolbar: FC<TDocumentToolbar> = ({
     const { currentOrderPageNumber, pageNumbers, onCurrentPageChange } = useTaskAnnotatorContext();
     const isLastPage = currentOrderPageNumber === countOfPages - 1;
     const isFirstPage = currentOrderPageNumber === 0;
+    const [pageInputValue, setPageInputValue] = useState(String(currentOrderPageNumber + 1));
+
+    useEffect(() => {
+        setPageInputValue(String(currentOrderPageNumber + 1));
+    }, [currentOrderPageNumber]);
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            const pageNumber = parseInt(pageInputValue, 10);
+            if (!isNaN(pageNumber)) {
+                const validPage = Math.min(Math.max(1, pageNumber), countOfPages);
+                onPickerValueChange(validPage);
+                setPageInputValue(String(validPage));
+            }
+        }
+    };
+
+    const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setPageInputValue(e.target.value);
+    };
 
     const pagesDataSource = useArrayDataSource(
         {
@@ -70,6 +90,15 @@ export const DocumentToolbar: FC<TDocumentToolbar> = ({
                     getName={(item) => String(item)}
                     selectionMode="single"
                     disableClear={true}
+                    searchPosition="input"
+                    valueType="id"
+                    rawProps={{
+                        input: {
+                            defaultValue: pageInputValue,
+                            onChange: handlePageInputChange,
+                            onKeyDown: handleKeyDown
+                        }
+                    }}
                 />
                 <FlexRow>
                     <span>of {countOfPages}</span>


### PR DESCRIPTION
- Added controlled input state management for PickerInput component
- Implemented useEffect to sync input value with current page changes
- Added direct keyboard event handling via rawProps.input
- Included input validation for page number boundaries
- Maintained existing dropdown selection functionality

Fixes issue where enter key press didn't navigate to selected page

https://github.com/user-attachments/assets/da37bbc8-4385-499e-9a84-038788efea22

