### PR TITLE
fix: Non-admin user can access files and tabs via direct link #777

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,7 +28,8 @@ import {
     JOBS_PAGE,
     MODELS_PAGE,
     PIPELINES_PAGE,
-    REPORTS_PAGE
+    REPORTS_PAGE,
+    CATEGORIES_PAGE
 } from './shared/constants/general';
 import { ProtectedRoute } from 'shared/components/protected-route';
 import { CategoriesTableConnector } from './connectors/categories-table-connector';
@@ -61,10 +62,10 @@ export const App = () => {
                         <ProtectedRoute path={DOCUMENTS_PAGE} component={DocumentsPage} />
                         <ProtectedRoute path={PIPELINES_PAGE} component={PipelinesPage} />
                         <ProtectedRoute path={JOBS_PAGE} component={JobsPage} />
+                        <ProtectedRoute path={CATEGORIES_PAGE} component={CategoriesTableConnector} />
                         <Route path={DASHBOARD_PAGE} component={DashboardPage} />
                         <Route path="/login" component={LoginPage} />
                         <Route path="/tasks/:taskId" component={TaskPage} />
-                        <Route path="/categories" component={CategoriesTableConnector} />
                         <Route path={MODELS_PAGE} component={ModelsPage} />
                         <Route path={BASEMENTS_PAGE} component={BasementsPage} />
                         <Route path={REPORTS_PAGE} component={ReportsPage} />

--- a/web/src/shared/constants/general.ts
+++ b/web/src/shared/constants/general.ts
@@ -1,5 +1,6 @@
 export const JOBS_PAGE = '/jobs';
 export const DOCUMENTS_PAGE = '/documents';
+export const CATEGORIES_PAGE = '/categories';
 export const DASHBOARD_PAGE = '/my tasks';
 export const MODELS_PAGE = '/models';
 export const PIPELINES_PAGE = '/pipelines';


### PR DESCRIPTION
Steps to reproduce:
Login as a non-admin user
Try to open http://badgerdoc-dev.westeurope.cloudapp.azure.com:8083/categories (f.e.) or any other page/tab that is shown only for admin users

Expected result:
Non-admin user should not have access to these pages

Expected result is met.

A non-admin user no longer has access to modify or annotate items they shouldn’t have access to. The only change they can make is creating a new Category. If it is not a requirement, it’s up to the backend to decide whether this endpoint should be restricted for non-admins. 

This pr blocks the Category route on the frontend side — all other routes are working fine.