### PR TITLE
feat:  Added 'Previous' button in the Upload Wizard #793

### DIFF
--- a/web/src/components/upload-files-control/upload-files-control.tsx
+++ b/web/src/components/upload-files-control/upload-files-control.tsx
@@ -1,21 +1,15 @@
 // temporary_disabled_rules
 /* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps */
 import React, { FC, useCallback } from 'react';
-import { Blocker } from '@epam/loveship';
 
 import { UploadForm, AttachedFiles } from 'components';
 
 type UploadFilesControlProps = {
     value: File[];
-    isLoading: boolean;
     onValueChange: (value: File[]) => void;
 };
 
-export const UploadFilesControl: FC<UploadFilesControlProps> = ({
-    value,
-    isLoading,
-    onValueChange
-}) => {
+export const UploadFilesControl: FC<UploadFilesControlProps> = ({ value, onValueChange }) => {
     const onFilesAdded = useCallback(
         (files: Array<File>) => {
             const changedValue = [...value];
@@ -46,7 +40,6 @@ export const UploadFilesControl: FC<UploadFilesControlProps> = ({
         >
             <UploadForm onFilesAdded={onFilesAdded}></UploadForm>
             <AttachedFiles files={value} onFileRemove={onFileRemove} />
-            {isLoading && <Blocker isEnabled={isLoading} />}
         </div>
     );
 };

--- a/web/src/components/upload-wizard/preprocessor/upload-wizard-preprocessor.tsx
+++ b/web/src/components/upload-wizard/preprocessor/upload-wizard-preprocessor.tsx
@@ -4,6 +4,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { FlexRow, IconButton, PickerInput, RadioInput, Text, Tooltip } from '@epam/loveship';
 import { ReactComponent as InfoIcon } from '@epam/assets/icons/common/notification-info-outline-18.svg';
 import { useArrayDataSource } from '@epam/uui';
+import { Blocker } from '@epam/loveship';
 
 import styles from './upload-wizard-preprocessor.module.scss';
 import { Operators, SortingDirection } from '../../../api/typings';
@@ -29,6 +30,7 @@ export type UploadWizardPreprocessorResult = {
 
 type UploadWizardPreprocessorProps = {
     onChange: (data: UploadWizardPreprocessorResult) => void;
+    isLoading?: boolean;
 };
 
 const languages = [
@@ -40,7 +42,7 @@ const languages = [
     { id: 6, language: 'Portuguese' }
 ];
 
-const UploadWizardPreprocessor: FC<UploadWizardPreprocessorProps> = ({ onChange }) => {
+const UploadWizardPreprocessor: FC<UploadWizardPreprocessorProps> = ({ onChange, isLoading }) => {
     const [preprocessor, setPreprocessor] = useState<number | null>(null);
     const [selectedLanguages, setLanguages] = useState<any[]>([]);
 
@@ -155,6 +157,7 @@ const UploadWizardPreprocessor: FC<UploadWizardPreprocessorProps> = ({ onChange 
                     getName={(item) => item?.language || ''}
                 />
             </div>
+            {isLoading && <Blocker isEnabled={isLoading} />}
         </div>
     );
 };

--- a/web/src/pages/upload-document-wizard/upload-document-wizard-page.tsx
+++ b/web/src/pages/upload-document-wizard/upload-document-wizard-page.tsx
@@ -145,11 +145,7 @@ export const UploadWizardPage = () => {
             content: (
                 <>
                     <div className={wizardStyles['content__body']}>
-                        <UploadFilesControl
-                            value={files}
-                            onValueChange={setFiles}
-                            isLoading={isLoading}
-                        />
+                        <UploadFilesControl value={files} onValueChange={setFiles} />
                     </div>
                     <div className={wizardStyles['content__footer']}>
                         {renderWizardButtons({
@@ -183,7 +179,10 @@ export const UploadWizardPage = () => {
             content: (
                 <>
                     <div className={wizardStyles['content__body']}>
-                        <UploadWizardPreprocessor onChange={setPreprocessorStepData} />
+                        <UploadWizardPreprocessor
+                            onChange={setPreprocessorStepData}
+                            isLoading={isLoading}
+                        />
                     </div>
                     <div className={wizardStyles['content__footer']}>
                         {renderWizardButtons({
@@ -191,7 +190,9 @@ export const UploadWizardPage = () => {
                                 await uploadFilesHandler();
                                 handleNext();
                             },
-                            onPreviousClick: handlePrev
+                            onPreviousClick: handlePrev,
+                            disableNextButton: isLoading,
+                            disablePrevButton: isLoading
                         })}
                     </div>
                 </>

--- a/web/src/shared/components/wizard/wizard/wizard.tsx
+++ b/web/src/shared/components/wizard/wizard/wizard.tsx
@@ -23,17 +23,24 @@ export const renderWizardButtons = ({
     onPreviousClick,
     onNextClick,
     nextButtonCaption,
-    disableNextButton
+    disableNextButton,
+    disablePrevButton
 }: {
     onPreviousClick?: any;
     onNextClick: any;
     nextButtonCaption?: string;
     disableNextButton?: boolean;
+    disablePrevButton?: boolean;
 }) => {
     return (
         <>
             {onPreviousClick ? (
-                <Button fill="light" caption="Previous" onClick={onPreviousClick} />
+                <Button
+                    fill="light"
+                    caption="Previous"
+                    onClick={onPreviousClick}
+                    isDisabled={disablePrevButton}
+                />
             ) : null}
             <Button
                 caption={nextButtonCaption || 'Next'}


### PR DESCRIPTION
* Added the "Previous" button to all steps except the last one, since the document upload has already been completed by then.
* Moved the spinner from UploadFilesControl to UploadWizardPreprocessorProps, as this is the step where the actual document upload takes place.