### PR TITLE
Add default empty string for KEYCLOAK_HOST to prevent None being passed to get_tenant_info

### DIFF
--- a/taxonomy/taxonomy/token_dependency.py
+++ b/taxonomy/taxonomy/token_dependency.py
@@ -7,7 +7,7 @@ import os
 
 from tenant_dependency import TenantData, get_tenant_info
 
-KEYCLOAK_HOST = os.getenv("KEYCLOAK_HOST")
+KEYCLOAK_HOST = os.getenv("KEYCLOAK_HOST", "")
 TOKEN = get_tenant_info(url=KEYCLOAK_HOST, algorithm="RS256")
 
 if os.getenv("TAXONOMY_NO_AUTH", False):


### PR DESCRIPTION
## Bug Fix: Missing null check for KEYCLOAK_HOST

### Problem
In `taxonomy/taxonomy/token_dependency.py`, the `KEYCLOAK_HOST` environment variable is retrieved without a default value:

```python
KEYCLOAK_HOST = os.getenv("KEYCLOAK_HOST")
```

When `KEYCLOAK_HOST` is not set, `os.getenv()` returns `None`, which is then passed to `get_tenant_info(url=KEYCLOAK_HOST, algorithm="RS256")`. This can cause the function to fail or behave unexpectedly.

### Solution
Add a default empty string value to prevent `None` from being passed:

```python
KEYCLOAK_HOST = os.getenv("KEYCLOAK_HOST", "")
```

### Impact
- Prevents potential runtime errors when `KEYCLOAK_HOST` is not configured
- Consistent with the pattern used in `annotation/annotation/token_dependency.py`
- Minimal change with no side effects

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.