### PR TITLE
Add support PNG upload

### DIFF
--- a/web/badgerdoc/models/document.py
+++ b/web/badgerdoc/models/document.py
@@ -77,7 +77,12 @@ class Document(TimestampedModel):
             child.delete()
 
         if self.file:
-            self.file.delete(save=False)
+            parent_uses_same_file = (
+                self.parent_document_id is not None
+                and self.parent_document.file.name == self.file.name
+            )
+            if not parent_uses_same_file:
+                self.file.delete(save=False)
 
         super().delete(*args, **kwargs)
 

--- a/web/badgerdoc/models/workflow_registry.py
+++ b/web/badgerdoc/models/workflow_registry.py
@@ -189,6 +189,10 @@ def get_registries(
             entity_tags=[]
         )
         queryset = queryset.filter(q_objects)
+    else:
+        queryset = queryset.filter(
+            models.Q(entity_tags__isnull=True) | models.Q(entity_tags=[])
+        )
 
     if temporal_workflow_type is not None:
         queryset = queryset.filter(

--- a/web/badgerdoc/models/workflow_registry.py
+++ b/web/badgerdoc/models/workflow_registry.py
@@ -141,9 +141,12 @@ def get_registries(
         document_types: List of document types to match. Returns registries where any of
             these types exist in the registry's document_types array, OR where the
             registry's document_types is None/empty (meaning it accepts any type)
-        entity_tags: List of entity tags to match. Returns registries where any of
-            these tags exist in the registry's entity_tags array, OR where the
-            registry's entity_tags is None/empty (meaning it accepts any tags)
+        entity_tags: List of entity tags to match.
+            - If None: tag filtering is skipped entirely (caller does not care about tags).
+            - If []: entity has no tags; only registries with no entity_tags requirement are returned.
+            - If non-empty: returns registries where any of these tags exist in the
+              registry's entity_tags array, OR where the registry's entity_tags is
+              None/empty (meaning it accepts any tags).
         temporal_workflow_type: Filter by Temporal workflow type/class name
         temporal_queue: Filter by Temporal task queue name
         is_active: Filter by active status (default: True)
@@ -189,7 +192,7 @@ def get_registries(
             entity_tags=[]
         )
         queryset = queryset.filter(q_objects)
-    else:
+    elif entity_tags is not None:
         queryset = queryset.filter(
             models.Q(entity_tags__isnull=True) | models.Q(entity_tags=[])
         )

--- a/web/badgerdoc/signals/workflow.py
+++ b/web/badgerdoc/signals/workflow.py
@@ -120,7 +120,7 @@ def get_supported_workflows(
 def get_supported_workflows_by_document(
     params: WorkflowParameters, doc: document.Document
 ) -> list[workflow_registry.WorkflowRegistry]:
-    entity_tags = doc.tags if doc.tags else None
+    entity_tags = doc.tags if doc.tags else []
     return get_supported_workflows(params, doc, entity_tags)
 
 
@@ -129,12 +129,12 @@ def get_supported_workflows_by_extraction(
     doc: document.Document,
     ext: extraction.Extraction,
 ) -> list[workflow_registry.WorkflowRegistry]:
-    entity_tags = ext.tags if ext.tags else None
+    entity_tags = ext.tags if ext.tags else []
     return get_supported_workflows(params, doc, entity_tags)
 
 
 def get_supported_workflows_by_task(
     params: WorkflowParameters, doc: document.Document, tsk: task.Task
 ) -> list[workflow_registry.WorkflowRegistry]:
-    entity_tags = tsk.tags if tsk.tags else None
+    entity_tags = tsk.tags if tsk.tags else []
     return get_supported_workflows(params, doc, entity_tags)

--- a/web/badgerdoc/views/document.py
+++ b/web/badgerdoc/views/document.py
@@ -331,6 +331,27 @@ def _parse_form_request_data(request: Request) -> dict[str, Any]:
     }
 
 
+def _create_rendition_from_png(document_obj: document.Document) -> None:
+    # Creates a rendition only from PNG uploads. For other file types (PDF, etc.),
+    # renditions are produced by the Convert workflows (see workflows/badgerdoc_convert).
+    if document_obj.parent_document is not None:
+        return
+    if document_obj.tags and "rendition" in document_obj.tags:
+        return
+    ext = (document_obj.extension or "").lower()
+    if ext != "png":
+        return
+    document.Document.objects.create(
+        file=document_obj.file,
+        name=document_obj.name,
+        extension=document_obj.extension,
+        uploaded_by=document_obj.uploaded_by,
+        parent_document=document_obj,
+        tags=["rendition"],
+        metadata={"page": 1},
+    )
+
+
 @swagger_auto_schema(
     method="post",
     operation_description="Create document and optionally upload a file",
@@ -366,6 +387,7 @@ def create_document(request: Request) -> Response:
         )
         serializer.is_valid(raise_exception=True)
         document_obj = serializer.save()
+        _create_rendition_from_png(document_obj)
 
         return Response(
             DocumentSerializer(document_obj).data,


### PR DESCRIPTION
Adds first-class handling for single-image PNG uploads by creating a rendition document immediately at upload time, and adjusts workflow registry filtering and document deletion behavior to better support this new flow.

**Changes:**

- Create a rendition child Document automatically when uploading a root PNG document.
- Tighten WorkflowRegistry.get_registries() behavior when entity_tags are not provided (or empty).
- Prevent double-deletion of the underlying file when a child document references the same stored file as its parent.
