### PR TITLE
fix(osd): disable default toolbar to stop 404 image requests

### DIFF
--- a/web/frontend/src/components/collection-viewer/config.ts
+++ b/web/frontend/src/components/collection-viewer/config.ts
@@ -6,6 +6,7 @@ export const NEXT_BTN_ID = 'viewer-next'
 export const PREV_BTN_ID = 'viewer-prev'
 
 export const DEFAULT_OSD_CONFIG: Options = {
+  showNavigationControl: false,
   // toolbar settings
   zoomInButton: ZOOM_IN_BTN_ID,
   zoomOutButton: ZOOM_OUT_BTN_ID,


### PR DESCRIPTION
OpenSeadragon was requesting default toolbar image assets `(home_*.png, fullpage_*.png)`, which returned 404.

The application uses custom toolbar controls, so default navigation controls are not needed.

Disabled default navigation UI via `showNavigationControl: false` to prevent unnecessary asset requests.