### PR TITLE
Add PNG rendering fallback when DZI tile assets are unavailable

### DIFF
--- a/web/frontend/src/components/collection-viewer/collection-viewer.tsx
+++ b/web/frontend/src/components/collection-viewer/collection-viewer.tsx
@@ -96,12 +96,16 @@ export function CollectionViewer({
     (effectivePages?.length ?? 0) > 0 && effectivePages!.every((p) => p.type === 'image')
   const effectiveCanUseEditMode = canUseEditMode && !isPngFallback
   const effectiveIsEditMode = isEditMode && !isPngFallback
+
+  const emptyOverlays = useMemo<Record<number, OverlayBox[]>>(() => ({}), [])
+  const emptyCreatedIds = useMemo<Set<string>>(() => new Set(), [])
+
   useExtractionHighlights({
     viewer,
-    overlayItems: isPngFallback ? {} : highlights,
+    overlayItems: isPngFallback ? emptyOverlays : highlights,
     selectedHighlightId: isPngFallback ? null : activeHighlightId,
     isEditMode: effectiveIsEditMode,
-    createdHighlightIds: isPngFallback ? new Set<string>() : createdHighlightIds,
+    createdHighlightIds: isPngFallback ? emptyCreatedIds : createdHighlightIds,
     onHighlightClick,
     onHighlightUpdate,
     onHighlightCreate,

--- a/web/frontend/src/components/collection-viewer/collection-viewer.tsx
+++ b/web/frontend/src/components/collection-viewer/collection-viewer.tsx
@@ -1,15 +1,16 @@
 import { ViewerToolbar, type PageChatContext } from '@/components/collection-viewer/viewer-toolbar'
 import { useViewerNavigation } from '@/components/collection-viewer/use-viewer-navigation'
 import { useOsdViewer } from '@/components/collection-viewer/use-osd-viewer'
-import { OverlayBox } from '@/shared/api/badgerdoc/types'
+import { OverlayBox, PageSource } from '@/shared/api/badgerdoc/types'
 import { useDocumentPages } from '@/shared/api/hooks/use-document-workspace'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useExtractionHighlights } from '@/components/collection-viewer/use-extraction-highlights.ts'
 import { useCurrentPageSync } from '@/components/collection-viewer/use-current-page-sync'
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getDocumentExtension } from '@/components/document-hierarchy-utils'
 import { cn, extractFilenameFromUrl } from '@/helpers/utils'
 import { getApiAdapter } from '@/shared/api/adapters/factory'
+import { logger } from '@/shared/logger'
 import { toast } from 'sonner'
 import { useTouchNavigation } from './use-touch-navigation'
 
@@ -53,26 +54,66 @@ export function CollectionViewer({
 }: CollectionViewerProps) {
   const { data: pages, isLoading } = useDocumentPages(documentId)
   const [isDownloading, setIsDownloading] = useState(false)
-  const { containerRef, viewer } = useOsdViewer(pages)
+  const adapter = getApiAdapter()
+
+  // Runtime PNG fallback: when /dzi/ returns URLs but OpenSeadragon fails to
+  // actually open the tiled source (broken/missing assets in storage), we
+  // fetch PNG renditions and rebuild the viewer with them. Reset whenever the
+  // document changes.
+  const [runtimeFallbackPages, setRuntimeFallbackPages] = useState<PageSource[] | null>(null)
+  const runtimeFallbackRequestedRef = useRef(false)
+  useEffect(() => {
+    setRuntimeFallbackPages(null)
+    runtimeFallbackRequestedRef.current = false
+  }, [documentId])
+
+  const handleOsdLoadFailed = useCallback(() => {
+    if (runtimeFallbackRequestedRef.current) return
+    runtimeFallbackRequestedRef.current = true
+
+    adapter.documents
+      .getPngPagesById(documentId)
+      .then((sources) => {
+        setRuntimeFallbackPages(sources)
+      })
+      .catch((error) => {
+        logger.error('Failed to fetch PNG renditions for OSD fallback', error)
+        // Stop retrying for this document; the viewer will stay empty rather
+        // than thrash the open-failed event in a loop.
+        setRuntimeFallbackPages([])
+      })
+  }, [adapter.documents, documentId])
+
+  const effectivePages = useMemo(() => runtimeFallbackPages ?? pages, [runtimeFallbackPages, pages])
+
+  const { containerRef, viewer } = useOsdViewer(effectivePages, {
+    onLoadFailed: handleOsdLoadFailed,
+  })
+  // When tiled (DZI) assets are unavailable, the viewer falls back to PNG
+  // rendering via OpenSeadragon's simple image source. In that mode the page
+  // is read-only: no overlays, no edit mode, no area selection.
+  const isPngFallback =
+    (effectivePages?.length ?? 0) > 0 && effectivePages!.every((p) => p.type === 'image')
+  const effectiveCanUseEditMode = canUseEditMode && !isPngFallback
+  const effectiveIsEditMode = isEditMode && !isPngFallback
   useExtractionHighlights({
     viewer,
-    overlayItems: highlights,
-    selectedHighlightId: activeHighlightId,
-    isEditMode,
-    createdHighlightIds,
+    overlayItems: isPngFallback ? {} : highlights,
+    selectedHighlightId: isPngFallback ? null : activeHighlightId,
+    isEditMode: effectiveIsEditMode,
+    createdHighlightIds: isPngFallback ? new Set<string>() : createdHighlightIds,
     onHighlightClick,
     onHighlightUpdate,
     onHighlightCreate,
   })
   const { goToPage } = useCurrentPageSync({
     viewer,
-    pages: pages || [],
+    pages: effectivePages || [],
     currentPage,
     setCurrentPage: onPageChange,
   })
 
-  const pagination = useViewerNavigation(pages?.length || 0, currentPage, goToPage)
-  const adapter = getApiAdapter()
+  const pagination = useViewerNavigation(effectivePages?.length || 0, currentPage, goToPage)
 
   useTouchNavigation(viewer)
 
@@ -124,9 +165,12 @@ export function CollectionViewer({
       if (!viewer) return
       // OSD types don't expose panHorizontal/panVertical on Viewer, but they exist at runtime.
       // Disabling pan keeps scroll-to-zoom and pinch-to-zoom working.
-      Object.assign(viewer, { panHorizontal: !isEditMode, panVertical: !isEditMode })
+      Object.assign(viewer, {
+        panHorizontal: !effectiveIsEditMode,
+        panVertical: !effectiveIsEditMode,
+      })
     },
-    [viewer, isEditMode]
+    [viewer, effectiveIsEditMode]
   )
 
   return (
@@ -138,8 +182,8 @@ export function CollectionViewer({
         onNextClick={pagination.handleNextClick}
         onPrevClick={pagination.handlePrevClick}
         onFitToPage={pagination.handleFitToPage}
-        isEditMode={isEditMode}
-        canUseEditMode={canUseEditMode}
+        isEditMode={effectiveIsEditMode}
+        canUseEditMode={effectiveCanUseEditMode}
         onToggleEditMode={onToggleEditMode}
         onDownloadOriginal={handleDownloadOriginal}
         isDownloading={isDownloading}
@@ -151,7 +195,7 @@ export function CollectionViewer({
         <div
           ref={containerRef}
           className={cn('relative w-full h-full bg-background', {
-            'cursor-crosshair': isEditMode,
+            'cursor-crosshair': effectiveIsEditMode,
           })}
           role="region"
           aria-label="Document viewer"

--- a/web/frontend/src/components/collection-viewer/use-current-page-sync.ts
+++ b/web/frontend/src/components/collection-viewer/use-current-page-sync.ts
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useCallback } from 'react'
 import OpenSeadragon from 'openseadragon'
+import type { PageSource } from '@/shared/api/badgerdoc/types'
 
 interface UseCurrentPageSyncParams {
   viewer: OpenSeadragon.Viewer | null
-  pages: string[]
+  pages: PageSource[]
   currentPage: number
   setCurrentPage: (page: number) => void
 }

--- a/web/frontend/src/components/collection-viewer/use-osd-viewer.ts
+++ b/web/frontend/src/components/collection-viewer/use-osd-viewer.ts
@@ -1,12 +1,37 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import OpenSeadragon, { Options, Viewer as OSDViewer } from 'openseadragon'
 import { logger } from '@/shared/logger.ts'
 import { DEFAULT_OSD_CONFIG, MACOS_OSD_CONFIG } from '@/components/collection-viewer/config'
 import { isMacOS } from '@/helpers/utils'
+import type { PageSource } from '@/shared/api/badgerdoc/types'
 
-export const useOsdViewer = (tileSources?: string[]) => {
+type OsdTileSource = string | { type: 'image'; url: string }
+
+const toOsdTileSource = (page: PageSource): OsdTileSource =>
+  page.type === 'image' ? { type: 'image', url: page.url } : page.url
+
+interface UseOsdViewerOptions {
+  /**
+   * Fired when OpenSeadragon reports that a tile source failed to initialize
+   * (the 'open-failed' event). Used as a runtime safety net so the caller can
+   * switch to PNG fallback when DZI assets are broken at the storage level
+   * but were still listed by the API.
+   */
+  onLoadFailed?: () => void
+}
+
+export const useOsdViewer = (pages?: PageSource[], options?: UseOsdViewerOptions) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [viewer, setViewer] = useState<OSDViewer | null>(null)
+
+  const tileSources = useMemo(() => pages?.map(toOsdTileSource), [pages])
+
+  // Keep the callback in a ref so changes in the caller's closure identity
+  // don't tear down and rebuild the viewer.
+  const onLoadFailedRef = useRef(options?.onLoadFailed)
+  useEffect(() => {
+    onLoadFailedRef.current = options?.onLoadFailed
+  }, [options?.onLoadFailed])
 
   useEffect(
     function initViewerForDocument() {
@@ -29,6 +54,11 @@ export const useOsdViewer = (tileSources?: string[]) => {
           if (firstItem) {
             osdViewer?.viewport.fitBounds(firstItem.getBounds())
           }
+        })
+
+        osdViewer.addHandler('open-failed', function handleOpenFailed(event) {
+          logger.warn('OSD failed to open tile source, requesting PNG fallback', event)
+          onLoadFailedRef.current?.()
         })
       } catch (error) {
         logger.error('Failed to initialize OSD viewer:', error)

--- a/web/frontend/src/features/workspace/components/document-popovers-regression.test.tsx
+++ b/web/frontend/src/features/workspace/components/document-popovers-regression.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { DocumentHierarchyPopover } from '@/components/document-hierarchy-popover'
-import type { BadgerDocDocument, Tag } from '@/shared/api/badgerdoc/types'
+import type { Tag } from '@/shared/api/badgerdoc/types'
 import type { DocumentHierarchyNode } from '@/shared/api/hooks/use-badgerdoc-document-hierarchy'
+import type { Document } from '@/shared/types/api'
 import { DocumentOverviewPopover } from './document-overview-popover'
 import type { OverviewDocument } from './document-overview-content'
 import { NoExtractionTagsEmptyState } from './no-extraction-tags-empty-state'
@@ -27,22 +28,29 @@ vi.mock('@/shared/api/hooks', () => ({
 }))
 
 vi.mock('@/shared/api/hooks/use-badgerdoc-document-hierarchy', () => ({
-  getBadgerDocDocumentTitle: (document: BadgerDocDocument) =>
+  getBadgerDocDocumentTitle: (document: Document) =>
     String(document.metadata?.title ?? document.id),
   useBadgerDocDocumentHierarchy: mocks.useHierarchy,
 }))
 
-function createDocument(id: number, title: string): BadgerDocDocument {
+function createDocument(id: number, title: string): Document {
   return {
-    id,
-    file: `https://example.test/${id}.pdf`,
+    id: String(id),
+    title,
+    type: 'report',
+    status: 'analysis_ready',
+    pdfUrl: `https://example.test/${id}.pdf`,
+    pageCount: 1,
     metadata: { title },
+    authors: [],
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
     tags: ['ocr'],
   }
 }
 
 function createNode(
-  document: BadgerDocDocument,
+  document: Document,
   options?: Partial<DocumentHierarchyNode>
 ): DocumentHierarchyNode {
   return {
@@ -71,7 +79,7 @@ function createOverviewDocument(): OverviewDocument {
   }
 }
 
-function mockHierarchy(currentDocument: BadgerDocDocument, childDocument: BadgerDocDocument) {
+function mockHierarchy(currentDocument: Document, childDocument: Document) {
   mocks.useHierarchy.mockImplementation(
     (document) =>
       ({

--- a/web/frontend/src/shared/api/adapters/mock/documents.ts
+++ b/web/frontend/src/shared/api/adapters/mock/documents.ts
@@ -6,6 +6,7 @@
 
 import type { DocumentsAdapter, DocumentsListParams, DocumentsListResponse } from '../types'
 import type { Document, DocumentStatus } from '@/shared/types/api'
+import type { PageSource } from '../../badgerdoc/types'
 import { mockDocuments } from '@/mocks/data/documents'
 
 // Simulated delay for realistic async behavior
@@ -89,13 +90,18 @@ export const mockDocumentsAdapter: DocumentsAdapter = {
     return doc
   },
 
-  getPagesById: async (_id: string): Promise<string[]> => {
+  getPagesById: async (_id: string): Promise<PageSource[]> => {
     await delay(1200)
     return [
-      `${__STATIC_ASSETS__}/dzi/2/page_1.dzi`,
-      `${__STATIC_ASSETS__}/dzi/2/page_2.dzi`,
-      `${__STATIC_ASSETS__}/dzi/2/page_3.dzi`,
+      { type: 'dzi', url: `${__STATIC_ASSETS__}/dzi/2/page_1.dzi` },
+      { type: 'dzi', url: `${__STATIC_ASSETS__}/dzi/2/page_2.dzi` },
+      { type: 'dzi', url: `${__STATIC_ASSETS__}/dzi/2/page_3.dzi` },
     ]
+  },
+
+  getPngPagesById: async (_id: string): Promise<PageSource[]> => {
+    await delay(200)
+    return []
   },
 
   approve: async (id: string): Promise<Document> => {

--- a/web/frontend/src/shared/api/adapters/real/documents.ts
+++ b/web/frontend/src/shared/api/adapters/real/documents.ts
@@ -8,8 +8,13 @@ import type { DocumentsAdapter, DocumentsListParams, DocumentsListResponse } fro
 import type { Document } from '@/shared/types/api'
 import { apiClient } from '../../client'
 import { badgerDocClient } from '../../badgerdoc/client'
-import type { BadgerDocDocument, BadgerDocDocumentsResponse } from '../../badgerdoc/types'
+import type {
+  BadgerDocDocument,
+  BadgerDocDocumentsResponse,
+  PageSource,
+} from '../../badgerdoc/types'
 import { transformBadgerDocDocument } from '../../badgerdoc'
+import { logger } from '@/shared/logger'
 
 function toDocumentsListResponse(response: BadgerDocDocumentsResponse): DocumentsListResponse {
   return {
@@ -23,6 +28,31 @@ function toDocumentsListResponse(response: BadgerDocDocumentsResponse): Document
 async function getBadgerDocDocument(id: string | number): Promise<BadgerDocDocument> {
   const response = await badgerDocClient.get<BadgerDocDocument>(`/document/${id}/`)
   return response.data
+}
+
+async function fetchDziPages(id: string): Promise<string[]> {
+  try {
+    const response = await badgerDocClient.get<string[]>(`/document/${id}/dzi/`)
+    return response.data ?? []
+  } catch (error) {
+    logger.warn('Failed to fetch DZI page list, will try PNG fallback', error)
+    return []
+  }
+}
+
+async function fetchPngRenditionPages(id: string): Promise<PageSource[]> {
+  const response = await badgerDocClient.get<BadgerDocDocument[]>(
+    `/document/${id}/renditions/`
+  )
+  const renditions = response.data ?? []
+  return renditions
+    .filter((doc) => Boolean(doc.file))
+    .sort((a, b) => {
+      const pageA = (a.metadata?.page as number | undefined) ?? 0
+      const pageB = (b.metadata?.page as number | undefined) ?? 0
+      return pageA - pageB
+    })
+    .map((doc) => ({ type: 'image', url: doc.file }))
 }
 
 export const realDocumentsAdapter: DocumentsAdapter = {
@@ -54,10 +84,20 @@ export const realDocumentsAdapter: DocumentsAdapter = {
     return transformBadgerDocDocument(bdDoc)
   },
 
-  getPagesById: async (id: string): Promise<string[]> => {
-    const response = await badgerDocClient.get<string[]>(`/document/${id}/dzi/`)
-    return response.data
+  /**
+   * Returns viewer page sources. Tiled (DZI) sources are primary; if the API
+   * returns no DZI assets, PNG renditions are returned as a static fallback so
+   * the document is still viewable read-only.
+   */
+  getPagesById: async (id: string): Promise<PageSource[]> => {
+    const dziUrls = await fetchDziPages(id)
+    if (dziUrls.length > 0) {
+      return dziUrls.map((url) => ({ type: 'dzi', url }))
+    }
+    return fetchPngRenditionPages(id)
   },
+
+  getPngPagesById: (id: string): Promise<PageSource[]> => fetchPngRenditionPages(id),
 
   approve: async (id: string): Promise<Document> => {
     const response = await apiClient.post<Document>(`/documents/${id}/approve`)

--- a/web/frontend/src/shared/api/adapters/real/documents.ts
+++ b/web/frontend/src/shared/api/adapters/real/documents.ts
@@ -46,8 +46,19 @@ async function fetchPngRenditionPages(id: string): Promise<PageSource[]> {
   return renditions
     .filter((doc) => Boolean(doc.file))
     .sort((a, b) => {
-      const pageA = (a.metadata?.page as number | undefined) ?? 0
-      const pageB = (b.metadata?.page as number | undefined) ?? 0
+      const pageA = Number(a.metadata?.page)
+      const pageB = Number(b.metadata?.page)
+      const hasValidPageA = Number.isFinite(pageA)
+      const hasValidPageB = Number.isFinite(pageB)
+      if (!hasValidPageA && !hasValidPageB) {
+        return 0
+      }
+      if (!hasValidPageA) {
+        return 1
+      }
+      if (!hasValidPageB) {
+        return -1
+      }
       return pageA - pageB
     })
     .map((doc) => ({ type: 'image', url: doc.file }))

--- a/web/frontend/src/shared/api/adapters/real/documents.ts
+++ b/web/frontend/src/shared/api/adapters/real/documents.ts
@@ -41,9 +41,7 @@ async function fetchDziPages(id: string): Promise<string[]> {
 }
 
 async function fetchPngRenditionPages(id: string): Promise<PageSource[]> {
-  const response = await badgerDocClient.get<BadgerDocDocument[]>(
-    `/document/${id}/renditions/`
-  )
+  const response = await badgerDocClient.get<BadgerDocDocument[]>(`/document/${id}/renditions/`)
   const renditions = response.data ?? []
   return renditions
     .filter((doc) => Boolean(doc.file))

--- a/web/frontend/src/shared/api/adapters/types.ts
+++ b/web/frontend/src/shared/api/adapters/types.ts
@@ -19,7 +19,12 @@ import type {
   UpdateTaskRequest,
 } from '@/shared/types/tasks'
 import { BadgerDocExtractionPage } from '@/shared/api/badgerdoc'
-import { BadgerDocExtraction, BadgerDocUploadResponse, Tag } from '@/shared/api/badgerdoc/types'
+import {
+  BadgerDocExtraction,
+  BadgerDocUploadResponse,
+  PageSource,
+  Tag,
+} from '@/shared/api/badgerdoc/types'
 
 // =============================================================================
 // Response Types
@@ -146,7 +151,12 @@ export interface DocumentsAdapter {
   list(params?: DocumentsListParams): Promise<DocumentsListResponse>
   getById(id: string): Promise<Document>
   updateById(id: string, tags: string[], metadata: string): Promise<Document>
-  getPagesById(id: string): Promise<string[]>
+  getPagesById(id: string): Promise<PageSource[]>
+  /**
+   * Returns PNG image page sources for the document, sourced from `/renditions/`.
+   * Used as an explicit runtime fallback when tiled (DZI) rendering fails.
+   */
+  getPngPagesById(id: string): Promise<PageSource[]>
   approve(id: string): Promise<Document>
   decline(id: string, reason?: string): Promise<Document>
 }

--- a/web/frontend/src/shared/api/badgerdoc/types.ts
+++ b/web/frontend/src/shared/api/badgerdoc/types.ts
@@ -82,6 +82,15 @@ export interface OverlayBox {
   page: number
 }
 
+/**
+ * Source descriptor for a single page in the document viewer.
+ *
+ * `dzi` is the primary tiled-rendering mode (Deep Zoom Image XML + PNG tiles).
+ * `image` is the PNG fallback used when tiled assets are unavailable; the
+ * viewer renders read-only without interactive overlays in this mode.
+ */
+export type PageSource = { type: 'dzi'; url: string } | { type: 'image'; url: string }
+
 // =============================================================================
 // Document Types
 // =============================================================================

--- a/web/frontend/src/shared/api/hooks/use-document-workspace.ts
+++ b/web/frontend/src/shared/api/hooks/use-document-workspace.ts
@@ -8,6 +8,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { getApiAdapter } from '../adapters/factory'
 import type { Document } from '@/shared/types/api'
+import type { PageSource } from '../badgerdoc/types'
 import { toast } from 'sonner'
 
 // =============================================================================
@@ -51,7 +52,7 @@ export function useDocumentPages(documentId: string) {
 
   return useQuery({
     queryKey: workspaceKeys.pages(documentId),
-    queryFn: (): Promise<string[]> => adapter.documents.getPagesById(documentId),
+    queryFn: (): Promise<PageSource[]> => adapter.documents.getPagesById(documentId),
     enabled: !!documentId,
   })
 }


### PR DESCRIPTION
## Summary

The document viewer relies on tiled DZI rendering through OpenSeadragon. When a document has no DZI assets (conversion didn't run, partially failed, or files in storage are missing/broken) the viewer cannot display any pages.

This PR introduces a PNG fallback that pulls the per-page PNG renditions from the existing `/document/{id}/renditions/` endpoint and feeds them into OpenSeadragon's simple-image source. When fallback is active the viewer operates in a read-only mode — overlays, area selection, and edit mode are disabled, but zoom / pan / fit-to-screen work as before.

## How it works

Two-tier detection so both data-level and runtime-level failures are covered:

1. **API-response check (primary).** `getDocumentPages` calls `/dzi/` first.
   If the response is empty or the call throws, it falls back to fetching  `/renditions/`, sorts the result by `metadata.page` ascending, and returns each PNG as `{ type: 'image', url }`.
2. **OSD runtime check (safety net).** `useOsdViewer` listens for OpenSeadragon's `open-failed` event. When DZI URLs are returned by the API but the underlying assets fail to load (e.g. files missing from MinIO), `CollectionViewer` fetches `/renditions/` and rebuilds the viewer with PNG sources. A ref guards against re-triggering for the same document.

A `PageSource` discriminated union (`{ type: 'dzi' | 'image', url }`) is threaded through the service layer, adapter contracts, and the React Query hook. `useOsdViewer` unwraps each entry to the appropriate OpenSeadragon tileSource shape (`string` for DZI, `{ type: 'image', url }` for PNG).

When `effectivePages` contains only image entries, the viewer enters read-only mode:
- The edit-mode pencil button is hidden via `canUseEditMode={false}`.
- `useExtractionHighlights` receives empty overlay items, null selection, and an empty created-id set, so no overlays are drawn and no MouseTrackers are attached.
- The rubberband-draw `useEffect` returns early because `isEditMode` is forced false.
- Pan stays enabled; the crosshair cursor never appears.