### PR TITLE
[#1123] Revert does not remove a newly created extraction block on tabs with no existing extractions

### DIFF
--- a/web/frontend/src/features/workspace/components/extraction-editor.test.tsx
+++ b/web/frontend/src/features/workspace/components/extraction-editor.test.tsx
@@ -178,6 +178,48 @@ describe('ExtractionEditor', () => {
     expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: 'start', behavior: 'smooth' })
   })
 
+  it('does not auto-accept changes when the editor unmounts during a revert', async () => {
+    const onAcceptChanges = vi.fn().mockResolvedValue(undefined)
+    const onRevertChanges = vi.fn()
+
+    const { container, getByRole, unmount } = render(
+      <ExtractionEditor
+        content={content}
+        hasUnsavedChanges={true}
+        onBaselineReady={vi.fn()}
+        onContentChange={vi.fn()}
+        onRevertChanges={onRevertChanges}
+        onAcceptChanges={onAcceptChanges}
+        onBlockDelete={vi.fn()}
+        selectedContextBlockIds={[]}
+        selectedContextPages={[]}
+        isWholeDocumentSelected={false}
+        onToggleBlockContext={vi.fn()}
+        activeBlockId={null}
+        onBlockSelect={vi.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-block-id="block_1_1"]')).not.toBeNull()
+    })
+
+    fireEvent.mouseDown(getByRole('button', { name: 'Revert' }))
+    fireEvent.click(getByRole('button', { name: 'Revert' }))
+
+    expect(onRevertChanges).toHaveBeenCalledTimes(1)
+
+    // Reverting on a tab that becomes empty unmounts the editor (onDestroy).
+    // The revert guard must keep onDestroy from re-persisting the discarded block.
+    unmount()
+
+    // onDestroy runs handleAcceptChanges asynchronously, so flush microtasks
+    // before asserting it was suppressed (a negative waitFor would pass at t=0).
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(onAcceptChanges).not.toHaveBeenCalled()
+  })
+
   it('disables block context actions when prompt context becomes unavailable', async () => {
     const onToggleBlockContext = vi.fn()
 

--- a/web/frontend/src/features/workspace/components/extraction-editor.tsx
+++ b/web/frontend/src/features/workspace/components/extraction-editor.tsx
@@ -129,6 +129,7 @@ const ExtractionEditor = ({
       onContentChange(editor.getHTML())
     },
     onDestroy: async () => {
+      if (isRevertingRef.current) return
       await handleAcceptChanges()
     },
     onFocus: () => {
@@ -174,6 +175,15 @@ const ExtractionEditor = ({
       }
     },
     [content, hasUnsavedChanges]
+  )
+
+  useEffect(
+    function clearRevertGuardWhenClean() {
+      if (!hasUnsavedChanges) {
+        isRevertingRef.current = false
+      }
+    },
+    [hasUnsavedChanges]
   )
 
   useEffect(
@@ -291,7 +301,6 @@ const ExtractionEditor = ({
       onBaselineReady(editor.getHTML())
     }
     onRevertChanges()
-    isRevertingRef.current = false
   }, [editor, onBaselineReady, onRevertChanges])
 
   const handleAcceptChanges = useCallback(async () => {


### PR DESCRIPTION
- Fix revert behavior for unsaved extraction on empty tabs.
- Add test to the case.